### PR TITLE
fix(discovery): parse comma-separated versions: requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `BundlerArtifactDiscovery#version_matches?` now correctly parses the documented
+  comma-separated single-string form of `versions:` (e.g. `">= 7.0, < 9.0"`).
+  Previously, `Gem::Requirement.new` rejected that form with `BadRequirementError`
+  (subclass of `ArgumentError`), which was caught and silently treated as a
+  version mismatch — installation would skip the artifact with a misleading
+  "does not satisfy" warning. The YAML list form (`versions: [">= 7.0", "< 9.0"]`)
+  was unaffected and continues to work.
+
 ## [0.2.0] - 2026-05-29
 
 ### Added

--- a/lib/rails/hyperdrive/bundler_artifact_discovery.rb
+++ b/lib/rails/hyperdrive/bundler_artifact_discovery.rb
@@ -171,8 +171,13 @@ module Rails
         [lines[1...absolute_closing].join, lines[(absolute_closing + 1)..].join]
       end
 
+      # Accepts both YAML list form (versions: [">= 6.0", "< 9.0"]) and the
+      # documented single-string comma form (versions: ">= 6.0, < 9.0").
+      # Gem::Requirement.new does not parse a single comma-separated string,
+      # so split such strings into separate constraints before instantiation.
       def version_matches?(requirement_str, version)
-        Gem::Requirement.new(*Array(requirement_str)).satisfied_by?(Gem::Version.new(version.to_s))
+        parts = Array(requirement_str).flat_map { |s| s.is_a?(String) ? s.split(",").map(&:strip) : s }
+        Gem::Requirement.new(*parts).satisfied_by?(Gem::Version.new(version.to_s))
       rescue ArgumentError
         false
       end

--- a/spec/hyperdrive/bundler_artifact_discovery_spec.rb
+++ b/spec/hyperdrive/bundler_artifact_discovery_spec.rb
@@ -152,6 +152,69 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
     end
   end
 
+  describe "versions: multi-constraint parsing" do
+    around { |ex| Dir.mktmpdir { |d| @dir = d; ex.run } }
+    let(:spec) { spec_double("dummy_gem", "1.4.2", @dir) }
+
+    def write_skill(name, body)
+      sdir = File.join(@dir, "lib", "dummy_gem", "hyperdrive", "skills", name)
+      FileUtils.mkdir_p(sdir)
+      File.write(File.join(sdir, "SKILL.md"), body)
+    end
+
+    it "accepts the documented comma-separated single-string form" do
+      write_skill("a", <<~MD)
+        ---
+        name: a
+        description: d
+        gem: dummy_gem
+        versions: ">= 1.0, < 2.0"
+        ---
+
+        # a
+      MD
+      warnings = []
+      results = described_class.discover(specs: [spec], warnings: warnings)
+      expect(warnings).to be_empty
+      expect(results.map(&:name)).to include("a")
+    end
+
+    it "accepts the YAML-list form" do
+      write_skill("b", <<~MD)
+        ---
+        name: b
+        description: d
+        gem: dummy_gem
+        versions:
+          - ">= 1.0"
+          - "< 2.0"
+        ---
+
+        # b
+      MD
+      warnings = []
+      results = described_class.discover(specs: [spec], warnings: warnings)
+      expect(warnings).to be_empty
+      expect(results.map(&:name)).to include("b")
+    end
+
+    it "still rejects an out-of-range version with either form" do
+      write_skill("c", <<~MD)
+        ---
+        name: c
+        description: d
+        gem: dummy_gem
+        versions: ">= 2.0, < 3.0"
+        ---
+
+        # c
+      MD
+      warnings = []
+      expect(described_class.discover(specs: [spec], warnings: warnings)).to be_empty
+      expect(warnings.join).to include("does not satisfy")
+    end
+  end
+
   describe "Artifact#to_h" do
     it "exposes the metadata fields without the body" do
       artifact = described_class.discover(specs: [dummy_spec]).find(&:skill?)


### PR DESCRIPTION
The contract documented in README and inline contract comments shows the multi-constraint form as a single comma-separated string:

```yml
    versions: ">= 7.0, < 9.0"
```

- `Gem::Requirement.new` does not parse that form — it raises `Gem::Requirement::BadRequirementError` (a subclass of `ArgumentError`).

- `BundlerArtifactDiscovery#version_matches?` rescued `ArgumentError` and returned `false`, so any artifact using the documented form was silently treated as version-mismatched and skipped with a misleading "does not satisfy" warning. The YAML-list form (`versions: [">= 7.0", "< 9.0"]`) happened to work because splatting an array of strings into `Gem::Requirement.new` is supported.

  Split a string `requirement_str` on `,` before instantiation so both documented forms work. Add regression specs for the comma form, the YAML list form, and out-of-range rejection.