### PR TITLE
docs: document companion gem contract rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented the companion gem contract rules the installer enforces but the
+  README omitted or misstated: the `hyperdrive_skills_dir` gemspec metadata
+  override (an additional skill root, not a replacement; `..` segments ignored),
+  the permissive failure model and where its warnings surface, within-gem
+  collapsing of same-`name:` artifacts, and both accepted forms of `versions:`.
+  Corrected the description of `name:` — it determines the installed path rather
+  than merely matching the file or directory stem.
+
 - **BREAKING:** renamed the `hyperdrive:init` / `hyperdrive:update` flag
   `--skip-skills` to `--skip-content`. The old name is removed outright, with no
   deprecated alias — it never described what the flag does. The flag skips *all*

--- a/README.md
+++ b/README.md
@@ -98,18 +98,32 @@ A companion gem ships artifacts under:
 <gem-source>/lib/<gem_name>/hyperdrive/guidelines/<name>.md         # guideline (flat file)
 ```
 
-with four required YAML frontmatter fields:
+Skills may ship under an additional root declared in gemspec metadata:
+
+```ruby
+spec.metadata["hyperdrive_skills_dir"] = "extra/skills"   # optional; relative to the gem root
+```
+
+That root is searched **in addition to** the convention path, never instead of it, so an override never hides skills already shipped at the convention path. A value containing a `..` segment is ignored. Guidelines have no override — they are found only at the convention path.
+
+Every artifact carries four required YAML frontmatter fields:
 
 ```yaml
 ---
-name: jobs-sidekiq                # kebab-case, equals filename/dir stem
+name: jobs-sidekiq                # kebab-case; determines the install path
 description: Background job conventions for Sidekiq.
 gem: sidekiq                      # the TARGET gem (resolved + version-matched in the bundle)
 versions: ">= 7.0, < 9.0"         # Gem::Requirement matched against the target gem
 ---
 ```
 
+`name:` is the artifact's identity, not a label — it is what the installer writes to disk (`.claude/skills/<name>/SKILL.md`, `.claude/hyperdrive/guidelines/<name>.md`). Keep it equal to the file or directory stem: if the two disagree the install still succeeds, but the artifact lands under `name:`. Within one gem, two artifacts of the same type declaring the same `name:` collapse to a single installed file; which one survives is not a guarantee to build on, so give each a distinct `name:`.
+
+`versions:` accepts either a single comma-separated string (`">= 7.0, < 9.0"`) or a YAML list (`[">= 7.0", "< 9.0"]`).
+
 `gem:` is the **target** (must be present in the bundle; its resolved version is matched against `versions:`). Use `railties` for "every Rails app" or the quoted `"*"` for "always applicable" (it must be quoted — bare `*` is a YAML alias and the file is skipped). `hyperdrive:init` discovers every such file across the bundle, version-matches it, and installs it with an audit header naming `source`, `sha256`, and `installed_at`. Guidelines are installed with their frontmatter stripped (they are `@`-included eagerly). When two gems ship a same-named artifact, both install, each postfixed by source gem.
+
+Discovery never raises. An artifact with missing or malformed frontmatter, a missing required field, a target gem absent from the bundle, or a resolved target version outside `versions:` is skipped, and the reason is collected. `hyperdrive:init` and `hyperdrive:update` print the collected reasons at the end of the run, under a yellow `warn` line reading `discovery skipped N artifact(s):`. A companion whose artifacts all fail therefore installs nothing and reports it only there — read that section first when a gem you expected to contribute produces no files.
 
 To be discoverable by `hyperdrive:discover` **before** it is installed, a companion also declares gemspec metadata (read remotely from rubygems, so the frontmatter inside the gem isn't visible yet):
 


### PR DESCRIPTION
Closes #6.

`rails-hyperdrive` ships no content of its own, so the companion gem contract section of `README.md` is the entire public specification an author works from. Several rules the installer actually enforces were missing from it or stated inaccurately. Because discovery is permissive — a violating artifact is skipped with a warning rather than rejected — an author who misread the contract got an install that quietly produced nothing.

Documentation only. No behavior changes.

## Rules now documented

- **`hyperdrive_skills_dir`** — the gemspec metadata override is searched *in addition to* the convention path, never instead of it, so it can never hide skills already shipped at the convention path. Values containing a `..` segment are ignored. Guidelines have no override.
- **The failure model** — missing or malformed frontmatter, a missing required field, an absent target gem, or a resolved version outside `versions:` skips that artifact and never raises. The section names where those warnings surface (the yellow `warn` line at the end of `init` / `update`), so an author whose companion produced no files knows where to look.
- **Within-gem collapsing** — two artifacts of the same type declaring the same `name:` collapse to a single installed file.
- **Both accepted forms of `versions:`** — the comma-separated string and the YAML list. The README showed only the string.

## Rule corrected

**`name:` determines the install destination.** The README described matching the file or directory stem as a convention (`# kebab-case, equals filename/dir stem`). The installer derives the destination from the frontmatter `name`, not from where the file ships, so an author whose stem and `name:` disagreed got a successful install into a directory they did not expect.

## One departure from the issue

The issue specified documenting within-gem collapsing as "highest `spec_version`, with path as the tiebreak," which is what the code literally reads. It is not what the code can do: the grouping key is `[name, source_gem, artifact_type]` and `spec_version` is taken from the source spec, so every member of a group carries the same version and the comparison always falls through to lexicographic path order. Publishing "highest `spec_version` wins" would document a rule that never fires.

The README instead states that duplicates collapse to one file, that which one survives is not a guarantee to build on, and that each artifact should get a distinct `name:`. Happy to state the literal ordering instead if preferred.

## Verification

`bundle exec rspec` — 172 examples, 0 failures. No linter is configured in this repo (no `.rubocop.yml`; neither the `Rakefile` nor `mise.toml` defines a lint task).
