### PR TITLE
feat(generator): warn on oversize eager context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A single requirement still applies to every listed target. Targets absent from
   the map are unconstrained.
 
+- `hyperdrive:init` / `hyperdrive:update` now check the *combined* eager
+  footprint against a budget, not just per-file size. When the guidelines
+  listed in `index.md` plus `stack.md` exceed ~10,000 tokens, the footprint
+  line is followed by a warning naming the two largest contributors, so it is
+  clear what to trim or which line to drop from `index.md` to opt a guideline
+  out. Individually reasonable guidelines could previously clear every per-file
+  check and still add up to real context-window pressure with nothing flagging
+  it. The install still proceeds — this is a warning, not a gate.
+
 ### Fixed
 
 - The MCP endpoint no longer 403s local requests whose `Origin` port differs

--- a/lib/generators/hyperdrive/install/install_generator.rb
+++ b/lib/generators/hyperdrive/install/install_generator.rb
@@ -43,6 +43,10 @@ module Rails
         WARN_LINES = 150
         WARN_TOKENS = 1_500
 
+        # Soft cap on the assembled eager set — roughly six at-the-limit
+        # guidelines, or ~5% of a 200k context window.
+        TOTAL_WARN_TOKENS = 10_000
+
         source_root File.expand_path("templates", __dir__)
 
         class_option :mount_at,      type: :string,  default: DEFAULT_MOUNT_AT, desc: "Engine mount path."
@@ -410,7 +414,7 @@ module Rails
             # Only guidelines actually referenced by index.md are eager; opted-out
             # ones stay on disk but out of context. Footprint counts the eager set.
             @index_guideline_count = included.size
-            @eager_guideline_bodies = included.map { |g| g[:body] }
+            @eager_entries = included.map { |g| { name: g[:base], body: g[:body] } }
 
             if existing == content
               say_status :unchanged, INDEX_PATH, :blue
@@ -463,11 +467,21 @@ module Rails
           end
 
           def print_footprint
-            bodies = Array(@eager_guideline_bodies).dup
-            bodies << @stack_body if @stack_body
-            tokens = bodies.sum { |b| approx_tokens(b) }
+            entries = Array(@eager_entries).dup
+            entries << { name: File.basename(STACK_PATH), body: @stack_body } if @stack_body
+            tokens = entries.sum { |e| approx_tokens(e[:body]) }
             count = @index_guideline_count.to_i
             say_status :eager, "#{count} guideline(s) + stack.md, ~#{tokens} tokens always in context", :cyan
+            warn_if_over_budget(entries, tokens)
+          end
+
+          def warn_if_over_budget(entries, tokens)
+            return unless tokens > TOTAL_WARN_TOKENS
+            top = entries.sort_by { |e| -approx_tokens(e[:body]) }.first(2)
+              .map { |e| "#{e[:name]} ~#{approx_tokens(e[:body])}" }
+            say_status :warn,
+              "eager context is over the ~#{TOTAL_WARN_TOKENS} token budget (largest: #{top.join(", ")}); trim them, or drop a line from #{INDEX_PATH} to opt one out",
+              :yellow
           end
 
           def warn_if_oversize(dest, body)

--- a/spec/hyperdrive/generators/install_generator_spec.rb
+++ b/spec/hyperdrive/generators/install_generator_spec.rb
@@ -399,6 +399,40 @@ RSpec.describe Rails::Generators::Hyperdrive::InstallGenerator do
     end
   end
 
+  describe "total eager budget warning" do
+    def guideline_of(name, tokens)
+      "---\nname: #{name}\ndescription: d\ngem: dummy_gem\nversions: \"~> 1.0\"\n---\n\n" + ("x" * (tokens * 4))
+    end
+
+    it "stays quiet while the assembled eager set is under the budget" do
+      stub_discovery([guideline_artifact(name: "small", source: "rails-hyperdrive-x", body: guideline_of("small", 100))])
+      expect(run_generator([])).not_to match(/token budget/)
+    end
+
+    it "warns and names the largest contributors when the total is over the budget" do
+      stub_discovery([
+        guideline_artifact(name: "huge", source: "rails-hyperdrive-x", body: guideline_of("huge", 9_000)),
+        guideline_artifact(name: "big", source: "rails-hyperdrive-x", body: guideline_of("big", 2_000)),
+        guideline_artifact(name: "tiny", source: "rails-hyperdrive-x", body: guideline_of("tiny", 10))
+      ])
+      out = run_generator([])
+      expect(out).to match(/eager context is over the ~10000 token budget/)
+      expect(out).to match(/largest: huge\.md ~\d+, big\.md ~\d+/)
+      expect(out).not_to include("tiny.md ~")
+    end
+
+    it "excludes guidelines the user opted out of" do
+      stub_discovery([
+        guideline_artifact(name: "huge", source: "rails-hyperdrive-x", body: guideline_of("huge", 12_000)),
+        guideline_artifact(name: "tiny", source: "rails-hyperdrive-x", body: guideline_of("tiny", 10))
+      ])
+      expect(run_generator([])).to match(/token budget/)
+
+      File.write(path(".claude/hyperdrive/index.md"), "@stack.md\n@guidelines/tiny.md\n")
+      expect(run_generator([])).not_to match(/token budget/)
+    end
+  end
+
   describe "CLAUDE.md opt-out state machine" do
     before { stub_discovery([]) }
 


### PR DESCRIPTION
Guidelines are eager — every one installed sits in the agent's context on every prompt. `hyperdrive:init` already measured that cost and printed it, but the number was informational: nothing compared it to anything. The per-file check catches a single bloated guideline, yet half a dozen individually reasonable ones can clear every per-file check and still add up to real context-window pressure, with nothing flagging it.

The footprint total is now checked against a 10,000-token budget. Over it, the footprint line is followed by a warning naming the two largest contributors:

```
     eager  3 guideline(s) + stack.md, ~11250 tokens always in context
      warn  eager context is over the ~10000 token budget (largest: huge.md ~9000,
            big.md ~2000); trim them, or drop a line from
            .claude/hyperdrive/index.md to opt one out
```

Naming the top files is the point — a bare total tells you there's a problem but not what to do about it, and the remedy (trimming a file, or removing its line from the guideline index) is per-file.

The threshold derives from the per-guideline limit already in use: at ~1,500 tokens per file, 10,000 is roughly six at-the-limit guidelines, or ~5% of a 200k context window. It reuses the same characters-over-four estimate as the per-file check so the two numbers stay comparable to anyone reading both. The install still proceeds — this is a warning, not a gate, matching the contract of the existing size checks.

Only hyperdrive-managed content counts: the guidelines listed in `index.md` plus `stack.md`. An app's own `CLAUDE.md` prose and independently wired imports are excluded, since the gem can't attribute them. Skills are excluded too — they load lazily and cost nothing until invoked. Guidelines the user has opted out of stay excluded from the sum, which the specs pin down: opting one out is the remedy the warning points at, so it has to move the number.

Closes #13