### PR TITLE
feat(init): add --skip-mcp flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `hyperdrive:init --skip-mcp` skips MCP setup entirely: no `rails-hyperdrive`
+  entry in `.mcp.json` and no engine mount in `config/routes.rb`. Content
+  install, the discover-cache `.gitignore` rule, and the bundler-plugin Gemfile
+  directive all still run, and the summary reports `MCP: skipped (--skip-mcp)`
+  in place of the mount/server lines. Like `--skip-content`, it only suppresses
+  writes — existing MCP configuration is left untouched — and the two flags
+  combine.
 - Companion-manifest `gem:` gating accepts a map with exactly one of `any:` or
   `all:`, so an artifact can require *every* listed target rather than any one
   of them: `gem: {all: [devise, pundit]}`. `any:` is an explicit spelling of the

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Companion gems ship two artifact types, tuned for how agents consume context:
 
 A companion gem declares in its manifest which gem each artifact targets and at which versions, so what lands in your app is what matches your `Gemfile.lock`, and nothing aimed at a library or version you don't run.
 
-With no companion gems, `hyperdrive:init` sets up just the server plumbing (`.mcp.json`, the engine mount, the lockfile) and puts **nothing** into your agent's context window.
+With no companion gems, `hyperdrive:init` sets up just the server plumbing (`.mcp.json`, the engine mount, the lockfile) and puts **nothing** into your agent's context window. The two halves are independently skippable: `--skip-mcp` installs content but no MCP plumbing, `--skip-content` the reverse. Neither removes anything already in place.
 
 ---
 

--- a/lib/generators/hyperdrive/install/USAGE
+++ b/lib/generators/hyperdrive/install/USAGE
@@ -11,6 +11,9 @@ Description:
         a guideline, and both removed when the last one goes
       - tracks everything in .hyperdrive/lock.yml
 
+    The .mcp.json entry and the engine mount are skippable with --skip-mcp;
+    existing MCP configuration is left untouched either way.
+
     Re-running re-syncs content and leaves locally-modified files untouched
     (skip + warn). Routine content refresh is bin/rails hyperdrive:sync
     (see its --merge, --sidecar, and --overwrite flags for reconciling
@@ -20,4 +23,5 @@ Examples:
     bin/rails hyperdrive:init
     bin/rails hyperdrive:init --mount-at /admin/hyperdrive
     bin/rails hyperdrive:init --skip-content
+    bin/rails hyperdrive:init --skip-mcp
     bin/rails hyperdrive:init --dry-run

--- a/lib/generators/hyperdrive/install/install_generator.rb
+++ b/lib/generators/hyperdrive/install/install_generator.rb
@@ -28,6 +28,7 @@ module Rails
 
         class_option :mount_at,      type: :string,  default: DEFAULT_MOUNT_AT, desc: "Engine mount path."
         class_option :skip_content,  type: :boolean, default: false, desc: "Skip all .claude content, CLAUDE.md, and the lockfile; write only .mcp.json and the mount."
+        class_option :skip_mcp,      type: :boolean, default: false, desc: "Skip MCP setup entirely; write no .mcp.json entry and no engine mount."
         class_option :dry_run,       type: :boolean, default: false, desc: "Show what would change; write nothing."
 
         def verify_environment
@@ -41,6 +42,8 @@ module Rails
         # The write is forced: Thor's conflict prompt would otherwise block the
         # run waiting on stdin.
         def write_mcp_json
+          return if options[:skip_mcp]
+
           existing = mcp_json_on_disk
           document = existing ? parse_mcp_json(existing) : {}
           return if document.nil?
@@ -80,6 +83,8 @@ module Rails
         end
 
         def mount_engine
+          return if options[:skip_mcp]
+
           routes_file = "config/routes.rb"
           unless File.exist?(::Rails.root.join(routes_file))
             say_status :skip, "no #{routes_file} found; skipping engine mount", :yellow
@@ -107,9 +112,16 @@ module Rails
         def print_summary
           say ""
           say_status :done, "hyperdrive initialized", :green
-          say "  Mount: #{mount_path} (in config/routes.rb)"
-          say "  Server: #{::Rails::Hyperdrive::McpServer::TOOLS.size} MCP tools at http://localhost:3000#{mount_path}/mcp"
+          if options[:skip_mcp]
+            say "  MCP: skipped (--skip-mcp)"
+          else
+            say "  Mount: #{mount_path} (in config/routes.rb)"
+            say "  Server: #{::Rails::Hyperdrive::McpServer::TOOLS.size} MCP tools at http://localhost:3000#{mount_path}/mcp"
+          end
           runner.summary_lines.each { |line| say line } unless options[:skip_content]
+          # Every next step is about reaching the MCP endpoint.
+          return if options[:skip_mcp]
+
           say ""
           say "  Next steps:"
           say "    1. bin/rails server"

--- a/lib/rails/commands/hyperdrive/hyperdrive_command.rb
+++ b/lib/rails/commands/hyperdrive/hyperdrive_command.rb
@@ -19,6 +19,7 @@ module Rails
       desc "init", "Install Rails Hyperdrive into this app (writes .mcp.json, CLAUDE.md, skills, guidelines, mounts engine)"
       option :mount_at, type: :string, default: "/_hyperdrive", desc: "Engine mount path."
       option :skip_content, type: :boolean, default: false, desc: "Skip all .claude content, CLAUDE.md, and the lockfile; write only .mcp.json and the mount."
+      option :skip_mcp, type: :boolean, default: false, desc: "Skip MCP setup entirely; write no .mcp.json entry and no engine mount."
       option :dry_run, type: :boolean, default: false, desc: "Show what would change; write nothing."
       def init(*)
         start_generator("install", "InstallGenerator")

--- a/spec/hyperdrive/generators/install_generator_spec.rb
+++ b/spec/hyperdrive/generators/install_generator_spec.rb
@@ -834,6 +834,65 @@ RSpec.describe Rails::Generators::Hyperdrive::InstallGenerator do
       expect(File.read(path(".hyperdrive/lock.yml"))).to include("state: present")
     end
 
+    it "honors --skip-mcp (no .mcp.json, no mount, everything else still written)" do
+      stub_discovery([guideline_artifact(name: "auth-pundit", source: "rails-hyperdrive-pundit")])
+      run_generator(["--skip-mcp"])
+      expect(File).not_to exist(path(".mcp.json"))
+      expect(File.read(path("config/routes.rb"))).not_to include("Rails::Hyperdrive::Engine")
+      expect(File).to exist(path(".hyperdrive/lock.yml"))
+      expect(File).to exist(path(".claude/hyperdrive/guidelines/auth-pundit.md"))
+      expect(File.read(path(".gitignore"))).to include(".hyperdrive/discover_cache.json")
+    end
+
+    it "leaves pre-existing MCP configuration byte-identical under --skip-mcp" do
+      mcp_json = %({\n  "mcpServers": {\n    "other": {\n      "url": "http://localhost:9000/mcp"\n    }\n  }\n}\n)
+      routes = %(Rails.application.routes.draw do\n  mount Rails::Hyperdrive::Engine => "/admin/hyperdrive" if Rails.env.development?\nend\n)
+      File.write(path(".mcp.json"), mcp_json)
+      File.write(path("config/routes.rb"), routes)
+
+      run_generator(["--skip-mcp"])
+      expect(File.read(path(".mcp.json"))).to eq(mcp_json)
+      expect(File.read(path("config/routes.rb"))).to eq(routes)
+    end
+
+    it "honors --skip-mcp --skip-content together" do
+      File.write(path("Gemfile"), %(source "https://rubygems.org"\n))
+      run_generator(["--skip-mcp", "--skip-content"])
+      expect(File).not_to exist(path(".mcp.json"))
+      expect(File.read(path("config/routes.rb"))).not_to include("Rails::Hyperdrive::Engine")
+      expect(File).not_to exist(path(".claude"))
+      expect(File).not_to exist(path("CLAUDE.md"))
+      expect(File).not_to exist(path(".hyperdrive/lock.yml"))
+      expect(File.read(path("Gemfile"))).to include('plugin "bundler-rails-hyperdrive"')
+      expect(File.read(path(".gitignore"))).to include(".hyperdrive/discover_cache.json")
+    end
+
+    it "ignores --mount-at under --skip-mcp" do
+      out = run_generator(["--skip-mcp", "--mount-at", "/admin/hyperdrive"])
+      expect(File).not_to exist(path(".mcp.json"))
+      expect(File.read(path("config/routes.rb"))).not_to include("/admin/hyperdrive")
+      expect(out).not_to match(/warn/i)
+    end
+
+    it "drops the mount, server, and next-steps lines from the --skip-mcp summary" do
+      stub_discovery([guideline_artifact(name: "auth-pundit", source: "rails-hyperdrive-pundit")])
+      out = run_generator(["--skip-mcp"])
+      expect(out).not_to match(/Mount:/)
+      expect(out).not_to match(/MCP tools/)
+      expect(out).not_to match(/Next steps/)
+      expect(out).to include("MCP: skipped (--skip-mcp)")
+      expect(out).to match(/Installed/)
+    end
+
+    it "writes .mcp.json and the mount on a later init after --skip-mcp" do
+      run_generator(["--skip-mcp"])
+      expect(File).not_to exist(path(".mcp.json"))
+
+      run_generator([])
+      expect(File.read(path(".mcp.json"))).to include("/_hyperdrive/mcp")
+      expect(File.read(path("config/routes.rb"))).to include("Rails::Hyperdrive::Engine")
+    end
+
     it "honors --mount-at in both the routes mount and the .mcp.json URL" do
       run_generator(["--mount-at", "/admin/hyperdrive"])
       expect(File.read(path("config/routes.rb"))).to include(%(mount Rails::Hyperdrive::Engine => "/admin/hyperdrive"))


### PR DESCRIPTION
`hyperdrive:init` had no way to opt out of the MCP surface. Apps that want the skills and guidelines but not a mounted MCP endpoint had to run init and then unwind the two writes by hand.

`--skip-mcp` is the mirror image of the existing `--skip-content`: it suppresses the `rails-hyperdrive` entry in `.mcp.json` and the engine mount in `config/routes.rb`, and drops the mount/server lines and the "Next steps" block from the summary in favour of a single `MCP: skipped (--skip-mcp)` note. Everything else init does — content install, the discover-cache `.gitignore` rule, the bundler-plugin Gemfile directive — runs unchanged.

Like `--skip-content`, the flag only suppresses writes. A pre-existing `.mcp.json` or routes mount is left byte-untouched, so it never tears down configuration a user already has. `--mount-at` only feeds the two suppressed writes, so combining it with `--skip-mcp` is a no-op rather than an error. The two skip flags combine: together they leave just the gitignore rule and the plugin directive.