### PR TITLE
fix(plugin): rescue ScriptError in bundle install hook

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,7 +47,9 @@ One-time setup, same as the root gem but with **workflow filename `release-plugi
 There is no bump script — cutting a release is manual:
 
 ```bash
-# 1. edit bundler-rails-hyperdrive/lib/bundler/hyperdrive/version.rb
+# 1. edit bundler-rails-hyperdrive/lib/bundler/hyperdrive/version.rb, and roll the
+#    ## [Unreleased] section of bundler-rails-hyperdrive/CHANGELOG.md into a dated
+#    ## [X.Y.Z] section (refreshing the link-reference footer)
 
 # 2. commit, then tag the commit with the namespaced tag
 git tag -a bundler-rails-hyperdrive/vX.Y.Z -m "bundler-rails-hyperdrive X.Y.Z"

--- a/bundler-rails-hyperdrive/CHANGELOG.md
+++ b/bundler-rails-hyperdrive/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to `bundler-rails-hyperdrive` are documented in this file.
+The gem versions and releases independently of `rails-hyperdrive`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2026-08-24
+
+### Fixed
+
+- The `bundle install` hook now rescues `ScriptError` (`LoadError`, `SyntaxError`)
+  alongside `StandardError`, in both `Bundler::Hyperdrive.auto_install` and the
+  hook block itself. A failure to load rails-hyperdrive's code — possible for any
+  release in the deliberately uncapped supported range — degrades to the usual
+  one-line `[hyperdrive] auto-install skipped (…)` report instead of failing the
+  user's `bundle install`.
+
+## [0.1.0] - 2026-08-04
+
+### Added
+
+- Initial release: an `after-install-all` Bundler hook that installs missing
+  hyperdrive artifacts during `bundle install`, with zero runtime dependencies.
+
+[Unreleased]: https://github.com/rails-hyperdrive/rails-hyperdrive/compare/bundler-rails-hyperdrive/v0.1.1...HEAD
+[0.1.1]: https://github.com/rails-hyperdrive/rails-hyperdrive/releases/tag/bundler-rails-hyperdrive/v0.1.1
+[0.1.0]: https://github.com/rails-hyperdrive/rails-hyperdrive/releases/tag/bundler-rails-hyperdrive/v0.1.0

--- a/bundler-rails-hyperdrive/bundler-rails-hyperdrive.gemspec
+++ b/bundler-rails-hyperdrive/bundler-rails-hyperdrive.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"]          = spec.homepage
   spec.metadata["source_code_uri"]       = spec.homepage
-  spec.metadata["changelog_uri"]         = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["changelog_uri"]         = "#{spec.homepage}/blob/main/bundler-rails-hyperdrive/CHANGELOG.md"
   spec.metadata["allowed_push_host"]     = "https://rubygems.org"
   spec.metadata["rubygems_mfa_required"] = "true"
 
@@ -30,7 +30,8 @@ Gem::Specification.new do |spec|
     Dir[
       "plugins.rb",
       "lib/**/*",
-      "LICENSE.txt"
+      "LICENSE.txt",
+      "CHANGELOG.md"
     ].reject { |f| File.directory?(f) }
   end
 

--- a/bundler-rails-hyperdrive/lib/bundler/hyperdrive.rb
+++ b/bundler-rails-hyperdrive/lib/bundler/hyperdrive.rb
@@ -34,7 +34,7 @@ module Bundler
       result.messages.each do |line|
         line.match?(/\A\s/) ? $stdout.puts(line) : report(line)
       end
-    rescue StandardError => e
+    rescue StandardError, ScriptError => e
       report "auto-install skipped (#{e.class}: #{e.message}); run bin/rails hyperdrive:sync manually"
       nil
     end

--- a/bundler-rails-hyperdrive/lib/bundler/hyperdrive/version.rb
+++ b/bundler-rails-hyperdrive/lib/bundler/hyperdrive/version.rb
@@ -1,5 +1,5 @@
 module Bundler
   module Hyperdrive
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.1".freeze
   end
 end

--- a/bundler-rails-hyperdrive/plugins.rb
+++ b/bundler-rails-hyperdrive/plugins.rb
@@ -1,5 +1,9 @@
 require_relative "lib/bundler/hyperdrive"
 
+# An exception escaping this block fails the user's `bundle install`, so this
+# rescue backs up auto_install's own.
 Bundler::Plugin.add_hook("after-install-all") do |_dependencies|
   Bundler::Hyperdrive.auto_install
+rescue StandardError, ScriptError => e
+  puts "[hyperdrive] auto-install skipped (#{e.class}: #{e.message}); run bin/rails hyperdrive:sync manually"
 end

--- a/spec/bundler_hyperdrive/hyperdrive_spec.rb
+++ b/spec/bundler_hyperdrive/hyperdrive_spec.rb
@@ -132,5 +132,18 @@ RSpec.describe Bundler::Hyperdrive do
 
       expect { run }.to output(/\A\[hyperdrive\] auto-install skipped \(ArgumentError: bad root\).*\n\z/).to_stdout
     end
+
+    # LoadError is a ScriptError, not a StandardError. `require` is stubbed
+    # because the real file is already loaded here, so a bad path never raises.
+    it "rescues a ScriptError raised while requiring the host gem" do
+      stub_bundle([host_spec("0.2.0")])
+      allow(described_class).to receive(:require)
+        .and_raise(LoadError, "cannot load such file -- rails/hyperdrive/auto_install")
+
+      expect { run }.to output(
+        "[hyperdrive] auto-install skipped (LoadError: cannot load such file -- " \
+        "rails/hyperdrive/auto_install); run bin/rails hyperdrive:sync manually\n"
+      ).to_stdout
+    end
   end
 end

--- a/spec/bundler_hyperdrive/plugins_spec.rb
+++ b/spec/bundler_hyperdrive/plugins_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "bundler/plugin"
+require_relative "../../bundler-rails-hyperdrive/lib/bundler/hyperdrive"
+
+RSpec.describe "bundler-rails-hyperdrive/plugins.rb" do
+  # `load`, not `require_relative`: the file may already be in $LOADED_FEATURES.
+  def registered_hook
+    captured = nil
+    allow(Bundler::Plugin).to receive(:add_hook) { |name, &block| captured = [name, block] }
+    load File.expand_path("../../bundler-rails-hyperdrive/plugins.rb", __dir__)
+    captured
+  end
+
+  it "registers the after-install-all hook" do
+    name, block = registered_hook
+
+    expect(name).to eq("after-install-all")
+    expect(block).to be_a(Proc)
+  end
+
+  it "degrades a ScriptError escaping auto_install to one printed line" do
+    _name, block = registered_hook
+    allow(Bundler::Hyperdrive).to receive(:auto_install)
+      .and_raise(LoadError, "cannot load such file -- rails/hyperdrive/auto_install")
+
+    expect { block.call(nil) }.to output(
+      "[hyperdrive] auto-install skipped (LoadError: cannot load such file -- " \
+      "rails/hyperdrive/auto_install); run bin/rails hyperdrive:sync manually\n"
+    ).to_stdout
+  end
+
+  it "degrades a StandardError escaping auto_install to one printed line" do
+    _name, block = registered_hook
+    allow(Bundler::Hyperdrive).to receive(:auto_install)
+      .and_raise(NoMethodError, "undefined method `auto_install'")
+
+    expect { block.call(nil) }.to output(
+      "[hyperdrive] auto-install skipped (NoMethodError: undefined method `auto_install'); " \
+      "run bin/rails hyperdrive:sync manually\n"
+    ).to_stdout
+  end
+end


### PR DESCRIPTION
The plugin's `after-install-all` hook has one hard contract: it must never fail a user's `bundle install`; every failure degrades to a single printed line. `Bundler::Hyperdrive.auto_install` rescued only `StandardError`, so a `LoadError` or `SyntaxError` — both `ScriptError`, which sits beside `StandardError` under `Exception` — would escape and take the install down with it.

That is reachable in practice. The supported rails-hyperdrive range (`>= 0.2`) is deliberately uncapped, and the hook does `require "rails/hyperdrive/auto_install"` against whatever the app's bundle resolved. A future release that moves a file in that require graph, or uses syntax the plugin's Ruby can't parse, lands squarely in range.

Two changes: `auto_install` now rescues `StandardError, ScriptError`, with the same one-line degradation and unchanged wording; and the hook block in `plugins.rb` gets its own rescue of the same pair. The second catches anything escaping `auto_install` itself — a future rename of the method would raise `NoMethodError` at the call site, outside the method's own rescue. It is deliberately self-contained (hardcoded prefix, plain `puts`, no `Bundler::Hyperdrive` constants) so it holds even if the module's internals change. `Exception` is still not rescued; `SignalException`, `SystemExit`, `NoMemoryError` and `SystemStackError` must keep propagating.

The plugin version goes to 0.1.1. 0.1.0 is already published, and installed Bundler plugins are never auto-updated nor pinned by the app's `Gemfile.lock`, so a broken rescue persists in the wild until someone reinstalls. The plugin gets its own `CHANGELOG.md` rather than an entry in the root one, since `bin/bump` rolls the root `## [Unreleased]` into root-gem release sections and would misattribute a plugin-only fix; the gemspec's `changelog_uri` and packaged file list follow, and the plugin release runbook in `RELEASING.md` now mentions rolling it.