### PR TITLE
feat: support-file templates in the template dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A template/content-paired skill's supporting files can be templated too: a
+  `*.md.erb` in the template directory renders against the app's bundle and
+  installs as `x.md`, so generic skills.sh consumers never copy raw ERB. Within
+  a paired skill a template-side file owns its target path — the content
+  directory's same-named file never installs, whether the template renders, is
+  gated out by `conditional:`, or fails to render.
+  `rake hyperdrive:skills:render` now writes each supporting template's
+  fail-open canonical face into the paired content directory, and
+  `rake hyperdrive:skills:check` byte-gates those faces and fails on any
+  `*.md.erb` found under a public skills root. A supporting `*.md.erb` shipped
+  under a public skills root still renders, but draws a warning steering it to
+  the template directory.
 - Companion-manifest `gem:` gating accepts a map with exactly one of `any:` or
   `all:`, so an artifact can require *every* listed target rather than any one
   of them: `gem: {all: [devise, pundit]}`. `any:` is an explicit spelling of the

--- a/lib/rails/hyperdrive/bundler_artifact_discovery.rb
+++ b/lib/rails/hyperdrive/bundler_artifact_discovery.rb
@@ -154,13 +154,14 @@ module Rails
         end
       end
 
-      # The content dir is the single source of truth for supporting files.
+      # The template dir holds only templates; static content is the paired
+      # content dir's to ship.
       def warn_template_extras(template_dir, warnings)
         extras = Dir.glob(File.join(template_dir, "**", "*"))
-                    .select { |f| File.file?(f) && f != File.join(template_dir, "SKILL.md.erb") }
+                    .select { |f| File.file?(f) && !erb_template?(f) }
         return if extras.empty?
-        warnings << "#{template_dir}: ignoring #{extras.size} file(s) besides SKILL.md.erb; " \
-                    "supporting files ship in the paired content directory"
+        warnings << "#{template_dir}: ignoring #{extras.size} file(s) besides SKILL.md.erb and " \
+                    "supporting *.md.erb templates; static supporting files ship in the paired content directory"
       end
 
       def guideline_paths(spec)
@@ -280,9 +281,9 @@ module Rails
           support_root: support_root,
           support_files:
             if type == :skill
-              conditioned_support_files(
-                support_root, gate.conditional,
-                resolved: resolved, warnings: warnings,
+              skill_support_files(
+                path, support_root, gate.conditional,
+                source_spec: source_spec, resolved: resolved, warnings: warnings,
                 label: "#{name} (from #{source_spec.name})"
               )
             else
@@ -303,14 +304,68 @@ module Rails
           rel = file.delete_prefix("#{skill_dir}/")
           next if SKILL_FILE_NAMES.include?(File.basename(rel))
           next if rel.split(%r{[/\\]}).include?("..")
-          { path: rel, body: File.binread(file) }
+          { path: rel, body: File.binread(file), root: skill_dir }
         end
       end
 
-      def conditioned_support_files(skill_dir, conditional, resolved:, warnings:, label:)
-        files = support_files_for(skill_dir)
-        files = apply_conditional_filter(files, conditional, resolved: resolved, warnings: warnings, label: label)
-        render_support_templates(files, skill_dir, resolved: resolved, warnings: warnings)
+      def template_support_files(template_dir)
+        return [] if template_dir.nil?
+        Dir.glob(File.join(template_dir, "**", "*.md.erb")).filter_map do |file|
+          next unless File.file?(file)
+          rel = file.delete_prefix("#{template_dir}/")
+          next if SKILL_FILE_NAMES.include?(File.basename(rel))
+          next if rel.split(%r{[/\\]}).include?("..")
+          { path: rel, body: File.binread(file), root: template_dir, template: true }
+        end
+      end
+
+      def skill_support_files(path, support_root, conditional, source_spec:, resolved:, warnings:, label:)
+        template_dir = File.dirname(path)
+        template_dir = nil if File.expand_path(template_dir) == File.expand_path(support_root)
+
+        conditioned_support_files(
+          support_root, conditional,
+          resolved: resolved, warnings: warnings, label: label,
+          template_dir: template_dir, source_root: source_spec.full_gem_path,
+          public_root: public_support_root?(source_spec, support_root)
+        )
+      end
+
+      def conditioned_support_files(skill_dir, conditional, resolved:, warnings:, label:,
+                                    template_dir:, source_root:, public_root:)
+        content = support_files_for(skill_dir)
+        templates = template_support_files(template_dir)
+        warn_public_support_templates(content, skill_dir, warnings) if public_root
+
+        # A template-side file owns its target path whatever its own outcome:
+        # installing the content-side face when the template is gated out or
+        # fails to render would silently un-condition the file.
+        claimed = templates.map { |f| target_path(f[:path]) }
+        files = apply_conditional_filter(content + templates, conditional,
+          resolved: resolved, warnings: warnings, label: label)
+        files = files.reject { |f| !f[:template] && claimed.include?(target_path(f[:path])) }
+
+        render_support_templates(files, resolved: resolved, warnings: warnings, source_root: source_root)
+      end
+
+      # Everything under a public skills root is copied verbatim by generic
+      # skills.sh consumers, so a template there hands them raw ERB.
+      def warn_public_support_templates(files, skill_dir, warnings)
+        return if files.none? { |f| erb_template?(f[:path]) }
+        warnings << "#{skill_dir}: supporting *.md.erb template(s) sit under a public skills root; " \
+                    "move them to the paired template directory and commit their rendered faces here"
+      end
+
+      def public_support_root?(spec, support_root)
+        dir = "#{File.expand_path(support_root)}/"
+        templates_root = File.join(spec.full_gem_path, skill_templates_dir(spec))
+        return false if dir.start_with?("#{File.expand_path(templates_root)}/")
+
+        roots = [File.join(spec.full_gem_path, "skills")]
+        if (override = skills_dir_override(spec))
+          roots << File.join(spec.full_gem_path, override)
+        end
+        roots.any? { |root| dir.start_with?("#{File.expand_path(root)}/") }
       end
 
       # Fail-open: a malformed condition warns and installs its file
@@ -361,28 +416,44 @@ module Rails
         match_targets(parsed.targets, versions, resolved, mode: parsed.match_mode).any?
       end
 
-      def render_support_templates(files, skill_dir, resolved:, warnings:)
+      def render_support_templates(files, resolved:, warnings:, source_root: nil)
         plain_paths = files.map { |f| f[:path] }
         files.filter_map do |file|
-          next file unless erb_template?(file[:path])
+          next { path: file[:path], body: file[:body] } unless erb_template?(file[:path])
 
-          target = file[:path].delete_suffix(".erb")
+          target = target_path(file[:path])
           if plain_paths.include?(target)
-            warnings << "skip #{File.join(skill_dir, file[:path])}: #{target} in the same directory takes precedence"
+            warnings << "skip #{File.join(file[:root], file[:path])}: #{target} in the same directory takes precedence"
             next nil
           end
 
           begin
-            { path: target, body: SkillTemplate.render(file[:body], resolved: resolved) }
+            rendered = { path: target, body: SkillTemplate.render(file[:body], resolved: resolved) }
           rescue SyntaxError, StandardError => e
-            warnings << "skip #{File.join(skill_dir, file[:path])}: ERB render failed (#{e.message})"
-            nil
+            warnings << "skip #{File.join(file[:root], file[:path])}: ERB render failed (#{e.message})"
+            next nil
           end
+          file[:template] ? rendered.merge(source_relpath: template_relpath(file, source_root)) : rendered
         end
+      end
+
+      # The relpath a later merge reconstructs the ancestor from: template-side,
+      # and .erb-stripped so AncestorLocator's twin fallback resolves it.
+      def template_relpath(file, source_root)
+        return nil if source_root.nil? || source_root.to_s.empty?
+
+        prefix = "#{File.expand_path(source_root.to_s)}/"
+        dir = File.expand_path(file[:root].to_s)
+        return nil unless dir.start_with?(prefix)
+        target_path(File.join(dir.delete_prefix(prefix), file[:path]))
       end
 
       def erb_template?(path)
         path.end_with?(".md.erb")
+      end
+
+      def target_path(path)
+        erb_template?(path) ? path.delete_suffix(".erb") : path
       end
 
       # Guideline frontmatter is stripped because the installed file is
@@ -478,9 +549,11 @@ module Rails
                            :resolve_same_dir_tie, :pair_with_templates, :warn_template_extras,
                            :opted_in?, :metadata_present?, :notice_skills_sh_content,
                            :skills_dir_override, :skill_templates_dir, :parse, :support_files_for,
-                           :conditioned_support_files, :apply_conditional_filter,
+                           :template_support_files, :skill_support_files,
+                           :conditioned_support_files, :warn_public_support_templates,
+                           :public_support_root?, :apply_conditional_filter,
                            :conditional_satisfied?,
-                           :render_support_templates, :erb_template?,
+                           :render_support_templates, :template_relpath, :erb_template?, :target_path,
                            :unmet_fence, :match_targets,
                            :version_satisfied?, :requirement_for, :no_match_reason,
                            :all_no_match_reason, :unsatisfied_reason, :safe_bundler_specs

--- a/lib/rails/hyperdrive/canonical_skill_render.rb
+++ b/lib/rails/hyperdrive/canonical_skill_render.rb
@@ -37,7 +37,7 @@ module Rails
         skills_root = File.join(gem_root, metadata_dir(spec, "rails_hyperdrive_skills_dir"))
         templates_root = File.join(gem_root, metadata_dir(spec, "rails_hyperdrive_skill_templates_dir"))
 
-        Dir.glob(File.join(templates_root, "**", "SKILL.md.erb")).sort.map do |template|
+        Dir.glob(File.join(templates_root, "**", "SKILL.md.erb")).sort.flat_map do |template|
           rel = File.dirname(template).delete_prefix(templates_root).delete_prefix("/")
           dest_dir = File.join(skills_root, rel)
           # A SKILL.md written beside the SKILL.md.erb would take precedence
@@ -50,8 +50,44 @@ module Rails
 
           body = render_template(template)
           validate_output!(body, template)
-          Rendered.new(template: template, dest: File.join(dest_dir, "SKILL.md"), body: body)
+          [Rendered.new(template: template, dest: File.join(dest_dir, "SKILL.md"), body: body)] +
+            support_renders(File.dirname(template), dest_dir)
         end
+      end
+
+      # Supporting files carry no frontmatter contract, so their faces are
+      # written unvalidated.
+      def support_renders(template_dir, dest_dir)
+        Dir.glob(File.join(template_dir, "**", "*.md.erb")).sort.filter_map do |template|
+          rel = template.delete_prefix("#{template_dir}/")
+          next if File.basename(rel) == "SKILL.md.erb"
+          Rendered.new(
+            template: template,
+            dest: File.join(dest_dir, rel.delete_suffix(".erb")),
+            body: render_template(template)
+          )
+        end
+      end
+
+      # A *.md.erb reachable through a public skills root is copied verbatim by
+      # generic skills.sh consumers.
+      def public_erb_templates(gemspec: nil, dir: Dir.pwd)
+        spec_path = resolve_gemspec_path(gemspec, dir)
+        spec = Gem::Specification.load(spec_path)
+        raise Error, "could not load gemspec #{spec_path}" unless spec
+
+        gem_root = File.dirname(File.expand_path(spec_path))
+        templates_dir = metadata_dir(spec, "rails_hyperdrive_skill_templates_dir")
+        templates_root = File.expand_path(File.join(gem_root, templates_dir))
+        roots = [File.join(gem_root, "skills")]
+        if (declared = declared_dir(spec, "rails_hyperdrive_skills_dir"))
+          roots << File.join(gem_root, declared)
+        end
+
+        roots.uniq { |r| File.expand_path(r) }
+             .flat_map { |root| Dir.glob(File.join(root, "**", "*.md.erb")) }
+             .reject { |path| File.expand_path(path).start_with?("#{templates_root}/") }
+             .uniq.sort
       end
 
       def resolve_gemspec_path(explicit, dir)
@@ -72,9 +108,12 @@ module Rails
       end
 
       def metadata_dir(spec, key)
-        default = File.join("lib", spec.name, "hyperdrive", "skills")
+        declared_dir(spec, key) || File.join("lib", spec.name, "hyperdrive", "skills")
+      end
+
+      def declared_dir(spec, key)
         raw = spec.metadata && spec.metadata[key]
-        return default if raw.nil? || raw.to_s.strip.empty?
+        return nil if raw.nil? || raw.to_s.strip.empty?
         raise Error, "gemspec metadata #{key} must not contain '..' segments" if
           raw.to_s.split(%r{[/\\]}).include?("..")
         raw.to_s
@@ -99,7 +138,8 @@ module Rails
         raise Error, "#{template}: rendered frontmatter is not parseable YAML"
       end
 
-      private_class_method :resolve_gemspec_path, :metadata_dir, :render_template, :validate_output!
+      private_class_method :support_renders, :resolve_gemspec_path, :metadata_dir, :declared_dir,
+                           :render_template, :validate_output!
     end
   end
 end

--- a/lib/rails/hyperdrive/install_pipeline.rb
+++ b/lib/rails/hyperdrive/install_pipeline.rb
@@ -128,7 +128,7 @@ module Rails
               source_gem: entry.source_gem,
               version: entry.version,
               artifact_kind: "skill_support",
-              source_relpath: support_base && File.join(support_base, file[:path])
+              source_relpath: file[:source_relpath] || (support_base && File.join(support_base, file[:path]))
             )
           end
         end

--- a/lib/rails/hyperdrive/install_plan.rb
+++ b/lib/rails/hyperdrive/install_plan.rb
@@ -19,7 +19,8 @@ module Rails
           return [] unless type == :skill
           dir = File.dirname(dest)
           Array(artifact.support_files).map do |file|
-            { path: file[:path], body: file[:body], dest: "#{dir}/#{file[:path]}" }
+            { path: file[:path], body: file[:body], dest: "#{dir}/#{file[:path]}",
+              source_relpath: file[:source_relpath] }
           end
         end
 

--- a/lib/rails/hyperdrive/skill_tasks.rb
+++ b/lib/rails/hyperdrive/skill_tasks.rb
@@ -13,15 +13,15 @@ namespace :hyperdrive do
       puts "no skill templates found" if written.empty?
     end
 
-    desc "Fail when a canonical SKILL.md is stale relative to its template"
+    desc "Fail when a canonical skill file is stale, or raw ERB sits under a public skills root"
     task :check, [:gemspec] do |_t, args|
       stale = Rails::Hyperdrive::CanonicalSkillRender.stale(gemspec: args[:gemspec])
-      if stale.empty?
-        puts "canonical skill files up to date"
-      else
-        stale.each { |r| warn "stale: #{r.dest}" }
-        abort "#{stale.size} canonical skill file(s) stale; run `rake hyperdrive:skills:render`"
-      end
+      raw = Rails::Hyperdrive::CanonicalSkillRender.public_erb_templates(gemspec: args[:gemspec])
+      stale.each { |r| warn "stale: #{r.dest}" }
+      raw.each { |p| warn "raw ERB: #{p}" }
+      abort "#{stale.size} canonical skill file(s) stale; run `rake hyperdrive:skills:render`" unless stale.empty?
+      abort "#{raw.size} ERB template(s) under a public skills root; move them to the template directory" unless raw.empty?
+      puts "canonical skill files up to date"
     end
   end
 end

--- a/spec/fixtures/smoke_companions/rails-hyperdrive-alpha/lib/rails-hyperdrive-alpha/hyperdrive/skills/alpha-skill/references/stack-notes.md.erb
+++ b/spec/fixtures/smoke_companions/rails-hyperdrive-alpha/lib/rails-hyperdrive-alpha/hyperdrive/skills/alpha-skill/references/stack-notes.md.erb
@@ -1,7 +1,7 @@
 # Stack Notes
 
 <%- if gem?("sqlite3") -%>
-This app persists to SQLite (sqlite3 <%= gem_version("sqlite3") %>).
+This app persists to SQLite (sqlite3 <%= gem_version("sqlite3") || "any version" %>).
 <%- end -%>
 <%- if gem?("alba") -%>
 This app serializes with Alba.

--- a/spec/fixtures/smoke_companions/rails-hyperdrive-alpha/skills/alpha-skill/references/stack-notes.md
+++ b/spec/fixtures/smoke_companions/rails-hyperdrive-alpha/skills/alpha-skill/references/stack-notes.md
@@ -1,0 +1,5 @@
+# Stack Notes
+
+This app persists to SQLite (sqlite3 any version).
+This app serializes with Alba.
+Rendered by hyperdrive at install time.

--- a/spec/hyperdrive/bundler_artifact_discovery_spec.rb
+++ b/spec/hyperdrive/bundler_artifact_discovery_spec.rb
@@ -1238,6 +1238,130 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
       expect(survivors.size).to eq(1)
       expect(survivors.first.path).to eq(File.join(@dir, "skills/dup/SKILL.md"))
     end
+
+    describe "template-side supporting templates" do
+      let(:support_template) { "notes: <%= gem?(\"sidekiq\") ? \"sidekiq\" : \"none\" %>\n" }
+
+      def paired_skill(template_files: {}, content_files: {}, manifest: nil)
+        write("skills/paired/SKILL.md", static_body)
+        write("lib/source_gem/hyperdrive/skills/paired/SKILL.md.erb", template_body)
+        template_files.each { |rel, body| write("lib/source_gem/hyperdrive/skills/paired/#{rel}", body) }
+        content_files.each { |rel, body| write("skills/paired/#{rel}", body) }
+        write("hyperdrive.yml", manifest) if manifest
+      end
+
+      def discover(*extra_specs, warnings: [])
+        [described_class.discover(specs: [paired_spec, *extra_specs], warnings: warnings).first, warnings]
+      end
+
+      it "renders a template-side supporting template against the bundle, retargeted to x.md" do
+        paired_skill(template_files: { "references/notes.md.erb" => support_template })
+
+        skill, warnings = discover(sidekiq)
+        expect(warnings).to be_empty
+        expect(skill.support_files.map { |f| f[:path] }).to contain_exactly("references/notes.md")
+        expect(skill.support_files.first[:body]).to eq("notes: sidekiq\n")
+      end
+
+      it "supersedes the content dir's same-target static face without a warning" do
+        paired_skill(
+          template_files: { "references/notes.md.erb" => support_template },
+          content_files: { "references/notes.md" => "canonical face\n" }
+        )
+
+        skill, warnings = discover
+        expect(warnings).to be_empty
+        expect(skill.support_files.map { |f| f[:path] }).to contain_exactly("references/notes.md")
+        expect(skill.support_files.first[:body]).to eq("notes: none\n")
+      end
+
+      it "installs nothing at the target path when the template fails to render" do
+        paired_skill(
+          template_files: { "references/notes.md.erb" => "<% raise 'boom' %>\n" },
+          content_files: { "references/notes.md" => "canonical face\n" }
+        )
+
+        skill, warnings = discover
+        expect(warnings.join).to include("notes.md.erb").and include("ERB render failed")
+        expect(skill.support_files).to eq([])
+      end
+
+      it "installs nothing at the target path when the template is gated out" do
+        paired_skill(
+          template_files: { "references/notes.md.erb" => support_template },
+          content_files: { "references/notes.md" => "canonical face\n" },
+          manifest: "skills:\n  paired:\n    conditional:\n      references/notes.md.erb:\n        gem: not_bundled\n"
+        )
+
+        skill, warnings = discover
+        expect(warnings).to be_empty
+        expect(skill.support_files).to eq([])
+      end
+
+      it "counts a template-side file as shipped for the conditional staleness check" do
+        paired_skill(
+          template_files: { "references/notes.md.erb" => support_template },
+          manifest: "skills:\n  paired:\n    conditional:\n      references/notes.md.erb:\n        gem: \"*\"\n" \
+                    "      references/gone.md:\n        gem: \"*\"\n"
+        )
+
+        _skill, warnings = discover
+        expect(warnings.join).to include("'references/gone.md' names no shipped supporting file")
+        expect(warnings.join).not_to include("'references/notes.md.erb' names no")
+      end
+
+      it "no longer warns about a supporting template in the template dir" do
+        paired_skill(template_files: { "references/notes.md.erb" => support_template })
+
+        _skill, warnings = discover
+        expect(warnings.join).not_to include("ignoring")
+      end
+
+      it "still warns about a non-template extra in the template dir" do
+        paired_skill(template_files: { "references/stray.md" => "stray\n" })
+
+        skill, warnings = discover
+        expect(warnings.join).to include("besides SKILL.md.erb")
+        expect(skill.support_files).to eq([])
+      end
+    end
+
+    describe "supporting templates under a public skills root" do
+      it "warns once and still renders a content-dir supporting template" do
+        write("skills/solo/SKILL.md", static_body("solo"))
+        write("skills/solo/references/a.md.erb", "a\n")
+        write("skills/solo/references/b.md.erb", "b\n")
+
+        warnings = []
+        skill = described_class.discover(specs: [paired_spec], warnings: warnings).first
+        expect(warnings.grep(/public skills root/).size).to eq(1)
+        expect(skill.support_files.map { |f| f[:path] })
+          .to contain_exactly("references/a.md", "references/b.md")
+      end
+
+      it "leaves a convention-root skill's supporting template unflagged" do
+        write("lib/source_gem/hyperdrive/skills/solo/SKILL.md", static_body("solo"))
+        write("lib/source_gem/hyperdrive/skills/solo/references/a.md.erb", "a\n")
+
+        warnings = []
+        skill = described_class.discover(specs: [paired_spec], warnings: warnings).first
+        expect(warnings).to be_empty
+        expect(skill.support_files.map { |f| f[:path] }).to eq(["references/a.md"])
+      end
+
+      it "warns about a masked content-dir supporting template too" do
+        write("skills/paired/SKILL.md", static_body)
+        write("skills/paired/references/notes.md.erb", "<% raise 'never rendered' %>\n")
+        write("lib/source_gem/hyperdrive/skills/paired/SKILL.md.erb", template_body)
+        write("lib/source_gem/hyperdrive/skills/paired/references/notes.md.erb", "templated\n")
+
+        warnings = []
+        skill = described_class.discover(specs: [paired_spec], warnings: warnings).first
+        expect(warnings.grep(/public skills root/).size).to eq(1)
+        expect(warnings.join).not_to include("ERB render failed")
+        expect(skill.support_files.map { |f| f[:body] }).to eq(["templated\n"])
+      end
+    end
   end
 
   describe "gem-root manifest gating" do

--- a/spec/hyperdrive/canonical_skill_render_spec.rb
+++ b/spec/hyperdrive/canonical_skill_render_spec.rb
@@ -155,6 +155,80 @@ RSpec.describe Rails::Hyperdrive::CanonicalSkillRender do
     end
   end
 
+  describe "supporting templates" do
+    let(:support) { "Notes for <%= gem_version(\"sqlite3\") || \"any version\" %>.\n" }
+
+    before do
+      write_gemspec
+      write("lib/paired_gem/hyperdrive/skills/paired/SKILL.md.erb", template)
+    end
+
+    it "renders each support face into the content dir, preserving layout" do
+      write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", support)
+
+      written = described_class.write(dir: @dir)
+      expect(written.map(&:dest)).to eq([
+        File.join(@dir, "skills/paired/SKILL.md"),
+        File.join(@dir, "skills/paired/references/notes.md")
+      ])
+      expect(File.read(File.join(@dir, "skills/paired/references/notes.md")))
+        .to eq("Notes for any version.\n")
+    end
+
+    it "writes a support face without frontmatter, unvalidated" do
+      write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", "# just prose\n")
+
+      expect { described_class.write(dir: @dir) }.not_to raise_error
+      expect(File.read(File.join(@dir, "skills/paired/references/notes.md"))).to eq("# just prose\n")
+    end
+
+    it "reports a missing and an out-of-date support face" do
+      write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", support)
+      expect(described_class.stale(dir: @dir).map(&:dest))
+        .to include(File.join(@dir, "skills/paired/references/notes.md"))
+
+      described_class.write(dir: @dir)
+      expect(described_class.stale(dir: @dir)).to be_empty
+
+      write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", support + "More.\n")
+      expect(described_class.stale(dir: @dir).map(&:dest))
+        .to eq([File.join(@dir, "skills/paired/references/notes.md")])
+    end
+  end
+
+  describe ".public_erb_templates" do
+    before { write_gemspec }
+
+    it "lists every *.md.erb reachable through a public skills root" do
+      write("skills/paired/SKILL.md.erb", template)
+      write("skills/paired/references/notes.md.erb", "notes\n")
+      write("skills/paired/references/keep.md", "keep\n")
+
+      expect(described_class.public_erb_templates(dir: @dir)).to eq([
+        File.join(@dir, "skills/paired/SKILL.md.erb"),
+        File.join(@dir, "skills/paired/references/notes.md.erb")
+      ])
+    end
+
+    it "excludes templates-root paths" do
+      write("lib/paired_gem/hyperdrive/skills/paired/SKILL.md.erb", template)
+      write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", "notes\n")
+
+      expect(described_class.public_erb_templates(dir: @dir)).to be_empty
+    end
+
+    it "scans the top-level skills dir even when it is not the declared root" do
+      write_gemspec(skills_dir: "public")
+      write("skills/loose/references/notes.md.erb", "notes\n")
+      write("public/paired/references/notes.md.erb", "notes\n")
+
+      expect(described_class.public_erb_templates(dir: @dir)).to eq([
+        File.join(@dir, "public/paired/references/notes.md.erb"),
+        File.join(@dir, "skills/loose/references/notes.md.erb")
+      ])
+    end
+  end
+
   describe "gemspec resolution" do
     it "errors when the working directory has no gemspec" do
       expect { described_class.write(dir: @dir) }

--- a/spec/hyperdrive/install_pipeline_spec.rb
+++ b/spec/hyperdrive/install_pipeline_spec.rb
@@ -253,13 +253,16 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
   describe "skill ancestry relpaths" do
     let(:locator) { Rails::Hyperdrive::AncestorLocator }
 
-    def skill_at(path:, source_root: "/gem", support_root: nil, version: "1.0.0", edition: "")
+    def skill_at(path:, source_root: "/gem", support_root: nil, version: "1.0.0", edition: "",
+                 support_relpath: nil)
       Artifact.new(
         name: "jobs", description: "d", target_gem: "*", versions: "*",
         artifact_type: :skill, source_gem: "rails-hyperdrive-x", path: path,
         body: "---\nname: jobs\ndescription: d\ngem: \"*\"\nversions: \"*\"\n---\n\n# jobs\n#{edition}",
         spec_version: version, source_root: source_root, support_root: support_root,
-        support_files: [{ path: "references/deep.md", body: "deep #{edition}\n" }]
+        support_files: [
+          { path: "references/deep.md", body: "deep #{edition}\n", source_relpath: support_relpath }
+        ]
       )
     end
 
@@ -282,6 +285,19 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
         .with(hash_including(kind: "skill", relpath: "lib/x/hyperdrive/skills/jobs/SKILL.md"))
       expect(locator).to have_received(:locate)
         .with(hash_including(kind: "skill_support", relpath: "skills/jobs/references/deep.md"))
+    end
+
+    it "locates a template-origin supporting file at the relpath discovery recorded" do
+      relpath = "lib/x/hyperdrive/skills/jobs/references/deep.md"
+      v1 = skill_at(path: "/gem/lib/x/hyperdrive/skills/jobs/SKILL.md.erb", support_root: "/gem/skills/jobs",
+        support_relpath: relpath)
+      v2 = skill_at(path: "/gem/lib/x/hyperdrive/skills/jobs/SKILL.md.erb", support_root: "/gem/skills/jobs",
+        version: "2.0.0", edition: "v2", support_relpath: relpath)
+
+      edit_installed_and_merge(v1, v2)
+
+      expect(locator).to have_received(:locate)
+        .with(hash_including(kind: "skill_support", relpath: relpath))
     end
 
     it "keeps today's relpaths for an unpaired artifact" do

--- a/spec/hyperdrive/skill_tasks_spec.rb
+++ b/spec/hyperdrive/skill_tasks_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe "hyperdrive:skills rake tasks" do
     end.to output(%r{stale: .*skills/paired/SKILL\.md}).to_stderr
   end
 
+  it "hyperdrive:skills:render writes a supporting template's static face too" do
+    write("lib/paired_gem/hyperdrive/skills/paired/references/notes.md.erb", "Notes.\n")
+
+    expect { invoke("hyperdrive:skills:render") }
+      .to output(%r{render .*skills/paired/references/notes\.md$}).to_stdout
+    expect(File.read(File.join(@dir, "skills/paired/references/notes.md"))).to eq("Notes.\n")
+  end
+
+  it "hyperdrive:skills:check fails listing raw ERB under a public skills root" do
+    quiet_render
+    write("skills/paired/references/notes.md.erb", "Notes.\n")
+
+    expect do
+      expect { invoke("hyperdrive:skills:check") }.to raise_error(SystemExit)
+    end.to output(%r{raw ERB: .*skills/paired/references/notes\.md\.erb}).to_stderr
+  end
+
   it "accepts an explicit gemspec path argument" do
     nested = File.join(@dir, "elsewhere")
     FileUtils.mkdir_p(nested)

--- a/spec/smoke/companion_install_spec.rb
+++ b/spec/smoke/companion_install_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe "hyperdrive companion install smoke", :smoke do
       gated_out = File.join(app_dir, ".claude/skills/alpha-skill/references/alba-notes.md")
       expect(File.exist?(gated_out)).to be(false), "gated-out supporting file installed:\n#{out}"
 
+      # The committed canonical face carries every branch, so an Alba-free body
+      # proves the template-side render superseded it.
       rendered = File.join(app_dir, ".claude/skills/alpha-skill/references/stack-notes.md")
       expect(File.exist?(rendered)).to be(true), "rendered .md.erb not installed:\n#{out}"
       stack_notes = File.read(rendered)
@@ -51,6 +53,7 @@ RSpec.describe "hyperdrive companion install smoke", :smoke do
       expect(stack_notes).not_to include("Alba")
       expect(stack_notes).not_to include("<%")
       expect(File.exist?(rendered + ".erb")).to be(false)
+      expect(out).not_to include("ignoring")
 
       guide_path = File.join(app_dir, ".claude/hyperdrive/guidelines/alpha-guide.md")
       expect(File.exist?(guide_path)).to be(true), "alpha-guide not installed:\n#{out}"


### PR DESCRIPTION
Template/content pairing lets a companion gem ship one master `SKILL.md.erb` template-side while the public `skills/` directory holds the static face generic skills.sh/npx consumers copy. Supporting files had no equivalent: the only place a supporting `*.md.erb` could live was that public content directory, so generic consumers got raw, unrendered ERB — the exact thing pairing exists to prevent.

A paired skill's template directory may now hold supporting `*.md.erb` at any depth. They render against the app's resolved bundle and install as `x.md`, unioned with the content directory's supporting files. Within a paired skill a template-side file claims its target path unconditionally: the content directory's same-target file never installs, whether the template rendered, failed to render, or was gated out by `conditional:`. Falling back to the content face would silently un-condition the file, the same reason a failing `SKILL.md.erb` skips its skill outright rather than parsing the static `SKILL.md`. Supersession is silent — it is the sanctioned layout working. `conditional:` keys stay shipped dir-relative paths and are applied before rendering, with both sides sharing one key namespace.

`rake hyperdrive:skills:render` now writes each supporting template's fail-open canonical face into the paired content directory, verbatim and without frontmatter validation (supporting files carry no frontmatter contract). `rake hyperdrive:skills:check` byte-gates those faces alongside the `SKILL.md` faces and additionally hard-fails listing any `*.md.erb` found under a public skills root — top-level `skills/` or a declared `rails_hyperdrive_skills_dir`, excluding the templates root. That is the author-facing enforcement of the no-raw-ERB promise. At discovery time, a supporting `*.md.erb` under a public root still renders as before so published companions keep working, but draws one warning steering it template-side.

Merge-mode ancestor lookup for template-origin supporting files uses a template-side source relpath with `.md.erb` normalized to `.md` — the same convention the paired skill definition already uses — so `AncestorLocator`'s existing `.erb`-twin fallback resolves it with no changes there and nothing new persisted in the lock. A companion migrating a supporting file from content-side to template-side will miss its ancestor on the first merge after the move and degrade to a sidecar, the normal fail-open rung.

Pairing still triggers only on a template `SKILL.md.erb`. A supporting `*.md.erb` in a template directory with no `SKILL.md.erb` beside it is inert — not discovered, not rendered, not flagged. Nothing changes outside pairing: standalone skills keep rendering their own content-directory templates, and the plain-wins same-directory tie rule is untouched.

The alpha smoke companion moves its `stack-notes.md.erb` to the template directory and commits the canonical face beside it, so the fixture models the full sanctioned layout and the smoke run proves precedence end to end. Documentation for the new layout lands separately.