### PR TITLE
feat: fence-first gating, author-side manifest lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `rake hyperdrive:manifest:check`, a strict author-side lint of a companion
+  gem's `hyperdrive.yml`, on the same companion-repo rake surface as
+  `hyperdrive:skills:*` (add `require "rails/hyperdrive/skill_tasks"` to the
+  Rakefile; takes the same optional gemspec-path argument). Where the installer
+  is permissive so a manifest written for a newer schema never blocks an
+  install, the lint fails: unknown keys at every level — the top level,
+  `skills:`/`guidelines:` entries, and `conditional:` entries — plus any
+  `gem:`/`gems:` or `hyperdrive_version:` value the installer cannot parse, and
+  `skills:`/`guidelines:`/`conditional:` keys naming nothing the gem ships. The
+  retired `versions:` key and its `version:` near-miss are named pointedly.
+  A manifest that lints clean draws no gating warning at install time.
 - A template/content-paired skill's supporting files can be templated too: a
   `*.md.erb` in the template directory renders against the app's bundle and
   installs as `x.md`, so generic skills.sh consumers never copy raw ERB. Within
@@ -112,6 +123,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (and `:sync` / `:discover`) is no longer available, and the tasks no longer
   appear in `bin/rails -T`. Use `bin/rails hyperdrive:<command>`, which is
   unchanged.
+
+### Fixed
+
+- A parseable `hyperdrive_version:` fence now survives an unusable `gem:`,
+  both per entry and in the gem-wide defaults. The fence is resolved before
+  the gate, so fail-open reads "install ungated unless fenced out": a manifest
+  written in a value shape an older installer cannot parse is fenced out of
+  that installer instead of installing everywhere unconstrained — the exact
+  case `hyperdrive_version:` exists to cover. The two gem-wide defaults are
+  independent too: an unusable `gem:` default no longer drops a parseable
+  fence, and a malformed fence no longer drops a usable `gem:` default; each
+  warns for its own axis. An entry whose *own* `hyperdrive_version:` is
+  unparsable still installs ungated and unfenced — the gem-wide fence is not
+  substituted for a constraint the entry never asked for.
 
 ## [0.6.0] - 2026-08-17
 

--- a/lib/rails/hyperdrive/bundler_artifact_discovery.rb
+++ b/lib/rails/hyperdrive/bundler_artifact_discovery.rb
@@ -551,8 +551,7 @@ module Rails
         []
       end
 
-      private_class_method :each_artifact_path, :warn_unknown_manifest_keys, :skill_paths,
-                           :guideline_paths,
+      private_class_method :each_artifact_path, :warn_unknown_manifest_keys,
                            :resolve_same_dir_tie, :pair_with_templates, :warn_template_extras,
                            :opted_in?, :metadata_present?, :notice_skills_sh_content,
                            :skills_dir_override, :skill_templates_dir, :parse, :support_files_for,

--- a/lib/rails/hyperdrive/canonical_skill_render.rb
+++ b/lib/rails/hyperdrive/canonical_skill_render.rb
@@ -1,6 +1,7 @@
 require "fileutils"
 require "yaml"
 require "rails/hyperdrive/bundler_artifact_discovery"
+require "rails/hyperdrive/gemspec_locator"
 require "rails/hyperdrive/skill_template"
 
 module Rails
@@ -9,7 +10,7 @@ module Rails
     # SKILL.md it pairs with, using the canonical fail-open binding.
     # Companion-repo dev tooling: problems raise.
     module CanonicalSkillRender
-      Error = Class.new(StandardError)
+      Error = GemspecLocator::Error
 
       Rendered = Struct.new(:template, :dest, :body, keyword_init: true)
 
@@ -29,13 +30,10 @@ module Rails
       end
 
       def render_all(gemspec: nil, dir: Dir.pwd)
-        spec_path = resolve_gemspec_path(gemspec, dir)
-        spec = Gem::Specification.load(spec_path)
-        raise Error, "could not load gemspec #{spec_path}" unless spec
-
-        gem_root = File.dirname(File.expand_path(spec_path))
-        skills_root = File.join(gem_root, metadata_dir(spec, "rails_hyperdrive_skills_dir"))
-        templates_root = File.join(gem_root, metadata_dir(spec, "rails_hyperdrive_skill_templates_dir"))
+        spec, gem_root = GemspecLocator.load_spec(gemspec, dir)
+        skills_root = File.join(gem_root, GemspecLocator.metadata_dir(spec, "rails_hyperdrive_skills_dir"))
+        templates_root =
+          File.join(gem_root, GemspecLocator.metadata_dir(spec, "rails_hyperdrive_skill_templates_dir"))
 
         Dir.glob(File.join(templates_root, "**", "SKILL.md.erb")).sort.flat_map do |template|
           rel = File.dirname(template).delete_prefix(templates_root).delete_prefix("/")
@@ -72,15 +70,11 @@ module Rails
       # A *.md.erb reachable through a public skills root is copied verbatim by
       # generic skills.sh consumers.
       def public_erb_templates(gemspec: nil, dir: Dir.pwd)
-        spec_path = resolve_gemspec_path(gemspec, dir)
-        spec = Gem::Specification.load(spec_path)
-        raise Error, "could not load gemspec #{spec_path}" unless spec
-
-        gem_root = File.dirname(File.expand_path(spec_path))
-        templates_dir = metadata_dir(spec, "rails_hyperdrive_skill_templates_dir")
+        spec, gem_root = GemspecLocator.load_spec(gemspec, dir)
+        templates_dir = GemspecLocator.metadata_dir(spec, "rails_hyperdrive_skill_templates_dir")
         templates_root = File.expand_path(File.join(gem_root, templates_dir))
         roots = [File.join(gem_root, "skills")]
-        if (declared = declared_dir(spec, "rails_hyperdrive_skills_dir"))
+        if (declared = GemspecLocator.declared_dir(spec, "rails_hyperdrive_skills_dir"))
           roots << File.join(gem_root, declared)
         end
 
@@ -88,35 +82,6 @@ module Rails
              .flat_map { |root| Dir.glob(File.join(root, "**", "*.md.erb")) }
              .reject { |path| File.expand_path(path).start_with?("#{templates_root}/") }
              .uniq.sort
-      end
-
-      def resolve_gemspec_path(explicit, dir)
-        if explicit && !explicit.to_s.strip.empty?
-          path = File.expand_path(explicit.to_s, dir)
-          raise Error, "gemspec not found: #{path}" unless File.file?(path)
-          return path
-        end
-
-        found = Dir.glob(File.join(dir, "*.gemspec"))
-        case found.size
-        when 1 then File.expand_path(found.first)
-        when 0 then raise Error, "no .gemspec found in #{dir}; pass an explicit path, " \
-                                 "e.g. rake \"hyperdrive:skills:render[path/to/name.gemspec]\""
-        else raise Error, "multiple gemspecs found in #{dir} " \
-                          "(#{found.map { |f| File.basename(f) }.join(", ")}); pass an explicit path"
-        end
-      end
-
-      def metadata_dir(spec, key)
-        declared_dir(spec, key) || File.join("lib", spec.name, "hyperdrive", "skills")
-      end
-
-      def declared_dir(spec, key)
-        raw = spec.metadata && spec.metadata[key]
-        return nil if raw.nil? || raw.to_s.strip.empty?
-        raise Error, "gemspec metadata #{key} must not contain '..' segments" if
-          raw.to_s.split(%r{[/\\]}).include?("..")
-        raw.to_s
       end
 
       def render_template(template)
@@ -138,8 +103,7 @@ module Rails
         raise Error, "#{template}: rendered frontmatter is not parseable YAML"
       end
 
-      private_class_method :support_renders, :resolve_gemspec_path, :metadata_dir, :declared_dir,
-                           :render_template, :validate_output!
+      private_class_method :support_renders, :render_template, :validate_output!
     end
   end
 end

--- a/lib/rails/hyperdrive/gem_manifest.rb
+++ b/lib/rails/hyperdrive/gem_manifest.rb
@@ -45,6 +45,16 @@ module Rails
           )
         end
 
+        # ".." segments are rejected (silent fallback to the conventional path)
+        # to prevent escaping the gem root.
+        def manifest_relpath(spec)
+          return FILE_NAME unless spec.respond_to?(:metadata)
+          raw = spec.metadata && spec.metadata[METADATA_KEY]
+          return FILE_NAME if raw.nil? || raw.to_s.strip.empty?
+          return FILE_NAME if raw.to_s.split(%r{[/\\]}).include?("..")
+          raw.to_s
+        end
+
         # The metadata key counts even when its value is unusable — declaring
         # it at all signals companion intent.
         def opt_in?(spec)
@@ -204,14 +214,8 @@ module Rails
         @warnings << "#{@spec.name}: #{message}"
       end
 
-      # ".." segments are rejected (silent fallback to the conventional path)
-      # to prevent escaping the gem root.
       def manifest_relpath
-        return FILE_NAME unless @spec.respond_to?(:metadata)
-        raw = @spec.metadata && @spec.metadata[METADATA_KEY]
-        return FILE_NAME if raw.nil? || raw.to_s.strip.empty?
-        return FILE_NAME if raw.to_s.split(%r{[/\\]}).include?("..")
-        raw.to_s
+        self.class.manifest_relpath(@spec)
       end
 
       # An empty file is a valid manifest (nothing gated); only content that
@@ -245,26 +249,40 @@ module Rails
         value.transform_keys(&:to_s)
       end
 
+      # Independent axes: an unusable gem: must not silence a parseable fence,
+      # the one gate that keeps content out of an installer too old to read it.
       def defaults(root)
+        report("manifest top-level #{VERSIONS_REMOVED}") if root.key?("versions")
+        [default_target_spec(root), default_fence(root)]
+      end
+
+      def default_target_spec(root)
         gem_key = self.class.gem_key(root)
         report("manifest top-level #{gem_key.warning}") if gem_key.warning
-        parsed = gem_key.present ? self.class.parse_targets(gem_key.value) : nil
-        bad_targets = gem_key.present && (parsed.nil? || parsed.targets.empty?)
-        if bad_targets || self.class.malformed_fence?(root["hyperdrive_version"])
-          report("manifest top-level gem:/hyperdrive_version: defaults are unusable; ignoring them")
-          return [nil, nil]
+        return nil unless gem_key.present
+
+        parsed = self.class.parse_targets(gem_key.value)
+        if parsed.nil? || parsed.targets.empty?
+          report("manifest top-level gem: default is unusable; ignoring it")
+          return nil
         end
-        report("manifest top-level #{VERSIONS_REMOVED}") if root.key?("versions")
-        report("manifest top-level gem: #{parsed.warning}") if parsed&.warning
-        [parsed, root["hyperdrive_version"]]
+        report("manifest top-level gem: #{parsed.warning}") if parsed.warning
+        parsed
+      end
+
+      def default_fence(root)
+        return root["hyperdrive_version"] unless self.class.malformed_fence?(root["hyperdrive_version"])
+
+        report("manifest top-level hyperdrive_version: default is unusable; ignoring it")
+        nil
       end
 
       def default_gate
         build_gate(@default_spec, hyperdrive_version: @default_fence)
       end
 
-      def ungated
-        build_gate(nil)
+      def ungated(hyperdrive_version: nil)
+        build_gate(nil, hyperdrive_version: hyperdrive_version)
       end
 
       def build_gate(target_spec, hyperdrive_version: nil, conditional: nil)
@@ -277,32 +295,37 @@ module Rails
         )
       end
 
-      # A malformed entry drops the gem-wide defaults too: gating that cannot
-      # be read must not skip the artifact, so it installs ungated.
+      # Gating that cannot be read must not skip the artifact, so a malformed
+      # entry installs ungated, gem-wide gem: default and all. The fence is
+      # resolved first and rides those fall-throughs — except where it is
+      # itself the unparsable part, since the gem-wide default would then apply
+      # a constraint this entry never asked for.
       def entry_gate(entry, key, with_conditional:)
         unless entry.is_a?(Hash)
           report("manifest entry for '#{key}' must be a map with gem:; installing ungated")
-          return ungated
+          return ungated(hyperdrive_version: @default_fence)
         end
 
         entry = entry.transform_keys(&:to_s)
+        if self.class.malformed_fence?(entry["hyperdrive_version"])
+          report("manifest entry for '#{key}' has an unparsable hyperdrive_version: requirement; installing ungated")
+          return ungated
+        end
+        fence = entry.key?("hyperdrive_version") ? entry["hyperdrive_version"] : @default_fence
+
         gem_key = self.class.gem_key(entry)
         report("manifest entry for '#{key}': #{gem_key.warning}") if gem_key.warning
         parsed = gem_key.present ? self.class.parse_targets(gem_key.value) : nil
         if gem_key.present && (parsed.nil? || parsed.targets.empty?)
           report("manifest entry for '#{key}': gem: must name #{GEM_FORMS}; installing ungated")
-          return ungated
-        end
-        if self.class.malformed_fence?(entry["hyperdrive_version"])
-          report("manifest entry for '#{key}' has an unparsable hyperdrive_version: requirement; installing ungated")
-          return ungated
+          return ungated(hyperdrive_version: fence)
         end
         report("manifest entry for '#{key}': #{VERSIONS_REMOVED}") if entry.key?("versions")
         report("manifest entry for '#{key}' gem: #{parsed.warning}") if parsed&.warning
 
         build_gate(
           parsed || @default_spec,
-          hyperdrive_version: entry.key?("hyperdrive_version") ? entry["hyperdrive_version"] : @default_fence,
+          hyperdrive_version: fence,
           conditional: with_conditional ? entry["conditional"] : nil
         )
       end

--- a/lib/rails/hyperdrive/gemspec_locator.rb
+++ b/lib/rails/hyperdrive/gemspec_locator.rb
@@ -1,0 +1,51 @@
+module Rails
+  module Hyperdrive
+    # Resolves the gemspec of the companion gem repo a dev task is running in,
+    # plus the directories its metadata declares. Companion-repo dev tooling:
+    # problems raise rather than fail open.
+    module GemspecLocator
+      Error = Class.new(StandardError)
+
+      module_function
+
+      # Returns the loaded spec and the repo root its relative paths resolve
+      # against — the gemspec's own directory, not an installed gem path.
+      def load_spec(explicit, dir)
+        path = resolve(explicit, dir)
+        spec = Gem::Specification.load(path)
+        raise Error, "could not load gemspec #{path}" unless spec
+
+        [spec, File.dirname(File.expand_path(path))]
+      end
+
+      def resolve(explicit, dir)
+        if explicit && !explicit.to_s.strip.empty?
+          path = File.expand_path(explicit.to_s, dir)
+          raise Error, "gemspec not found: #{path}" unless File.file?(path)
+          return path
+        end
+
+        found = Dir.glob(File.join(dir, "*.gemspec"))
+        case found.size
+        when 1 then File.expand_path(found.first)
+        when 0 then raise Error, "no .gemspec found in #{dir}; pass an explicit path as the task " \
+                                 "argument, e.g. rake \"<task>[path/to/name.gemspec]\""
+        else raise Error, "multiple gemspecs found in #{dir} " \
+                          "(#{found.map { |f| File.basename(f) }.join(", ")}); pass an explicit path"
+        end
+      end
+
+      def metadata_dir(spec, key)
+        declared_dir(spec, key) || File.join("lib", spec.name, "hyperdrive", "skills")
+      end
+
+      def declared_dir(spec, key)
+        raw = spec.metadata && spec.metadata[key]
+        return nil if raw.nil? || raw.to_s.strip.empty?
+        raise Error, "gemspec metadata #{key} must not contain '..' segments" if
+          raw.to_s.split(%r{[/\\]}).include?("..")
+        raw.to_s
+      end
+    end
+  end
+end

--- a/lib/rails/hyperdrive/manifest_lint.rb
+++ b/lib/rails/hyperdrive/manifest_lint.rb
@@ -1,0 +1,204 @@
+require "yaml"
+require "rails/hyperdrive/bundler_artifact_discovery"
+require "rails/hyperdrive/gem_manifest"
+require "rails/hyperdrive/gemspec_locator"
+
+module Rails
+  module Hyperdrive
+    # Author-side check of a companion gem's hyperdrive.yml, run in the
+    # companion's own repo. Where the installer warns and falls open — so that
+    # a manifest written for a newer schema never blocks an install — this
+    # fails, and unknown keys fail outright: the author's own rails-hyperdrive
+    # is the one that knows the whole schema. A manifest that passes draws no
+    # gating warning at install time.
+    module ManifestLint
+      Error = GemspecLocator::Error
+
+      ROOT_KEYS = %w[gem gems hyperdrive_version skills guidelines].freeze
+      SKILL_ENTRY_KEYS = %w[gem gems hyperdrive_version conditional].freeze
+      GUIDELINE_ENTRY_KEYS = %w[gem gems hyperdrive_version].freeze
+      CONDITIONAL_ENTRY_KEYS = %w[gem gems].freeze
+      RETIRED_VERSION_KEYS = %w[versions version].freeze
+      RETIRED_VERSION_HINT = "is not a gating key; put the requirement on the gem: member, " \
+                             "e.g. `- name: \">= 1.0\"`".freeze
+
+      # `manifest` is nil when the gem ships none, which is legal.
+      Result = Struct.new(:manifest, :problems, keyword_init: true)
+
+      # Discovery resolves every root against an installed gem's path; in the
+      # companion's repo that is the checkout.
+      RepoSpec = Struct.new(:name, :full_gem_path, :metadata, keyword_init: true)
+
+      module_function
+
+      def check(gemspec: nil, dir: Dir.pwd)
+        spec, gem_root = GemspecLocator.load_spec(gemspec, dir)
+        relpath = GemManifest.manifest_relpath(spec)
+        path = File.join(gem_root, relpath)
+        return Result.new(manifest: nil, problems: []) unless File.file?(path)
+
+        repo_spec = RepoSpec.new(name: spec.name, full_gem_path: gem_root, metadata: spec.metadata || {})
+        Result.new(manifest: relpath, problems: problems_in(path, repo_spec))
+      end
+
+      def problems_in(path, repo_spec)
+        problems = []
+        root = parse_root(path, problems)
+        return problems if root.nil?
+
+        check_keys(root, ROOT_KEYS, "top level", problems)
+        check_gate(root, "top level", problems)
+
+        skills = shipped_skills(repo_spec)
+        each_entry(root, "skills", skills.keys, "skill directory", problems) do |key, entry|
+          where = "skills entry '#{key}'"
+          check_keys(entry, SKILL_ENTRY_KEYS, where, problems)
+          check_gate(entry, where, problems)
+          check_conditional(entry["conditional"], where, skills[key], problems) if entry.key?("conditional")
+        end
+
+        guidelines = shipped_guidelines(repo_spec)
+        each_entry(root, "guidelines", guidelines, "guideline", problems) do |key, entry|
+          where = "guidelines entry '#{key}'"
+          check_keys(entry, GUIDELINE_ENTRY_KEYS, where, problems)
+          check_gate(entry, where, problems)
+        end
+
+        problems
+      end
+
+      # nil means nothing further is readable; an empty manifest is legal.
+      def parse_root(path, problems)
+        root = YAML.safe_load(File.read(path), permitted_classes: [Symbol])
+        return {} if root.nil?
+        return root.transform_keys(&:to_s) if root.is_a?(Hash)
+
+        problems << "root must be a YAML map"
+        nil
+      rescue Psych::SyntaxError => e
+        problems << "malformed YAML (#{e.message})"
+        nil
+      rescue StandardError => e
+        problems << "unreadable (#{e.message})"
+        nil
+      end
+
+      def each_entry(root, section, shipped, shipped_label, problems)
+        value = root[section]
+        return if value.nil?
+        unless value.is_a?(Hash)
+          problems << "#{section}: must be a map of #{shipped_label} keys to gating maps"
+          return
+        end
+
+        value.each do |key, entry|
+          key = key.to_s
+          problems << "#{section} entry '#{key}' names no shipped #{shipped_label}" unless shipped.include?(key)
+          unless entry.is_a?(Hash)
+            problems << "#{section} entry '#{key}' must be a map of gating keys"
+            next
+          end
+          yield key, entry.transform_keys(&:to_s)
+        end
+      end
+
+      def check_keys(map, allowed, where, problems)
+        (map.keys - allowed).each do |key|
+          problems << if RETIRED_VERSION_KEYS.include?(key)
+            "#{where}: '#{key}:' #{RETIRED_VERSION_HINT}"
+          else
+            "#{where}: unknown key '#{key}'#{did_you_mean(key, allowed)}; " \
+              "allowed keys are #{allowed.join(", ")}"
+          end
+        end
+      end
+
+      def did_you_mean(key, allowed)
+        near = allowed.find { |a| a.start_with?(key) || key.start_with?(a) }
+        near ? " (did you mean '#{near}'?)" : ""
+      end
+
+      # The parse rules come from GemManifest itself, so a form it accepts is
+      # never reported here and a form it falls open on always is. A parser
+      # warning counts as a failure: it names a spelling that installs, but not
+      # as written.
+      def check_gate(map, where, problems, fence: true)
+        problems << "#{where}: gem: and gems: are aliases; keep only one" if map.key?("gem") && map.key?("gems")
+
+        gem_key = GemManifest.gem_key(map)
+        if gem_key.present
+          parsed = GemManifest.parse_targets(gem_key.value)
+          if parsed.nil? || parsed.targets.empty?
+            problems << "#{where}: gem: must name #{GemManifest::GEM_FORMS}"
+          elsif parsed.warning
+            problems << "#{where}: gem: #{parsed.warning}"
+          end
+        end
+
+        return unless fence && map.key?("hyperdrive_version")
+        return unless GemManifest.malformed_fence?(map["hyperdrive_version"])
+        problems << "#{where}: hyperdrive_version: must be a version requirement, e.g. \">= 0.8\""
+      end
+
+      # `shipped` is nil when the owning skills entry names no shipped
+      # directory, which is already reported — every key would repeat it.
+      def check_conditional(value, where, shipped, problems)
+        unless value.is_a?(Hash)
+          problems << "#{where}: conditional: must be a map of supporting-file path to a gating map"
+          return
+        end
+
+        value.each do |key, entry|
+          key = key.to_s
+          inner = "#{where} conditional key '#{key}'"
+          if BundlerArtifactDiscovery::SKILL_FILE_NAMES.include?(key)
+            problems << "#{inner}: the entry's own gem: gates the whole skill"
+          elsif shipped && !shipped.include?(key)
+            problems << "#{inner}: names no shipped supporting file"
+          end
+
+          unless entry.is_a?(Hash)
+            problems << "#{inner}: must be a map with gem:"
+            next
+          end
+          entry = entry.transform_keys(&:to_s)
+          check_keys(entry, CONDITIONAL_ENTRY_KEYS, inner, problems)
+          check_gate(entry, inner, problems, fence: false)
+          problems << "#{inner}: gem: is required" unless GemManifest.gem_key(entry).present
+        end
+      end
+
+      # Maps each skill's manifest key to the dir-relative paths of its
+      # supporting files, as shipped: a template-side file is keyed by its
+      # *.md.erb name, the one a conditional: entry names.
+      def shipped_skills(repo_spec)
+        found = BundlerArtifactDiscovery.skill_paths(repo_spec, warnings: [])
+        found.each_with_object({}) do |(path, support_root, rel), h|
+          template_dir = File.dirname(path)
+          template_dir = nil if File.expand_path(template_dir) == File.expand_path(support_root)
+          h[rel] = h.fetch(rel, []) |
+                   support_paths(support_root, "**/*") | support_paths(template_dir, "**/*.md.erb")
+        end
+      end
+
+      def support_paths(root, glob)
+        return [] if root.nil?
+
+        Dir.glob(File.join(root, glob)).filter_map do |file|
+          next unless File.file?(file)
+          rel = file.delete_prefix("#{root}/")
+          next if BundlerArtifactDiscovery::SKILL_FILE_NAMES.include?(File.basename(rel))
+          rel
+        end
+      end
+
+      def shipped_guidelines(repo_spec)
+        BundlerArtifactDiscovery.guideline_paths(repo_spec).map { |p| File.basename(p) }
+      end
+
+      private_class_method :problems_in, :parse_root, :each_entry, :check_keys, :did_you_mean,
+                           :check_gate, :check_conditional, :shipped_skills, :support_paths,
+                           :shipped_guidelines
+    end
+  end
+end

--- a/lib/rails/hyperdrive/skill_tasks.rb
+++ b/lib/rails/hyperdrive/skill_tasks.rb
@@ -1,8 +1,9 @@
 # Rake tasks for companion gem repos: add `require "rails/hyperdrive/skill_tasks"`
-# to the Rakefile. Both tasks take an optional gemspec-path argument, e.g.
+# to the Rakefile. Every task takes an optional gemspec-path argument, e.g.
 # rake "hyperdrive:skills:render[path/to/name.gemspec]".
 require "rake"
 require "rails/hyperdrive/canonical_skill_render"
+require "rails/hyperdrive/manifest_lint"
 
 namespace :hyperdrive do
   namespace :skills do
@@ -22,6 +23,16 @@ namespace :hyperdrive do
       abort "#{stale.size} canonical skill file(s) stale; run `rake hyperdrive:skills:render`" unless stale.empty?
       abort "#{raw.size} ERB template(s) under a public skills root; move them to the template directory" unless raw.empty?
       puts "canonical skill files up to date"
+    end
+  end
+
+  namespace :manifest do
+    desc "Fail on unknown keys, unparsable gating, or entries naming nothing shipped in hyperdrive.yml"
+    task :check, [:gemspec] do |_t, args|
+      result = Rails::Hyperdrive::ManifestLint.check(gemspec: args[:gemspec])
+      result.problems.each { |p| warn "#{result.manifest}: #{p}" }
+      abort "#{result.problems.size} problem(s) in #{result.manifest}" unless result.problems.empty?
+      puts result.manifest ? "#{result.manifest} is clean" : "no hyperdrive.yml; nothing to lint"
     end
   end
 end

--- a/spec/hyperdrive/bundler_artifact_discovery_spec.rb
+++ b/spec/hyperdrive/bundler_artifact_discovery_spec.rb
@@ -1581,7 +1581,7 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
       write("hyperdrive.yml", "gem: [nested_list_entry, [oops]]\n")
 
       results, warnings = discover
-      expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
+      expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
       expect(results.first.target_gem).to eq(["*"])
     end
 
@@ -1686,14 +1686,43 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
         expect(fence_warnings).to be_empty
       end
 
-      it "installs unfenced and ungated on a malformed top-level fence" do
+      it "installs unfenced but still gated on a malformed top-level fence" do
         write_skill("a")
         write("hyperdrive.yml", "gem: sidekiq\nhyperdrive_version: garbage\n")
 
-        results, warnings, fence_warnings = discover_fenced
-        expect(results.first.target_gem).to eq(["*"])
-        expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
+        results, warnings, fence_warnings = discover_fenced(sidekiq)
+        expect(results.first.target_gem).to eq(["sidekiq"])
+        expect(warnings.grep(/top-level hyperdrive_version: default is unusable/).size).to eq(1)
         expect(fence_warnings).to be_empty
+      end
+
+      it "fences out an artifact whose gem: is unparsable rather than installing it ungated" do
+        write_skill("a")
+        write("hyperdrive.yml", <<~YAML)
+          skills:
+            a:
+              gem:
+                none: [sqlite3]
+              hyperdrive_version: ">= 99"
+        YAML
+
+        results, warnings, fence_warnings = discover_fenced
+        expect(results).to be_empty
+        expect(fence_warnings).to eq(
+          ["skill 'a' (from source_gem) requires rails-hyperdrive >= 99 (this is 0.6.0); " \
+           "upgrade rails-hyperdrive to install it"]
+        )
+        expect(warnings).to include(*fence_warnings)
+      end
+
+      it "fences out every artifact when the top-level gem: default is unparsable" do
+        write_skill("a")
+        write("hyperdrive.yml", "gem:\n  none: [sqlite3]\nhyperdrive_version: \">= 99\"\n")
+
+        results, warnings, fence_warnings = discover_fenced
+        expect(results).to be_empty
+        expect(fence_warnings).to all(include("requires rails-hyperdrive >= 99"))
+        expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
       end
 
       it "installs unfenced and ungated on a malformed per-entry fence" do

--- a/spec/hyperdrive/gem_manifest_spec.rb
+++ b/spec/hyperdrive/gem_manifest_spec.rb
@@ -328,6 +328,66 @@ RSpec.describe Rails::Hyperdrive::GemManifest do
     end
   end
 
+  describe "fence-first evaluation" do
+    it "keeps an entry's own fence when its gem: is unparsable" do
+      write("hyperdrive.yml", <<~YAML)
+        skills:
+          a:
+            gem:
+              none: [sqlite3]
+            hyperdrive_version: ">= 0.9"
+      YAML
+      manifest, warnings = load_manifest
+      expect(manifest.skill_gate("a").to_h)
+        .to include(targets: ["*"], versions: nil, hyperdrive_version: ">= 0.9")
+      expect(warnings.join).to include("gem: must name a gem")
+    end
+
+    it "falls back to the gem-wide fence when an entry with an unparsable gem: declares none" do
+      write("hyperdrive.yml", "hyperdrive_version: \">= 0.9\"\nskills:\n  a:\n    gem:\n      none: [sqlite3]\n")
+      manifest, = load_manifest
+      expect(manifest.skill_gate("a").to_h).to include(targets: ["*"], hyperdrive_version: ">= 0.9")
+    end
+
+    it "keeps the gem-wide fence on a non-map entry" do
+      write("hyperdrive.yml", "gem: railties\nhyperdrive_version: \">= 0.9\"\nskills:\n  a: yes\n")
+      manifest, warnings = load_manifest
+      expect(manifest.skill_gate("a").to_h).to include(targets: ["*"], hyperdrive_version: ">= 0.9")
+      expect(warnings.join).to include("manifest entry for 'a' must be a map")
+    end
+
+    it "installs unfenced on an entry's own malformed fence, never substituting the default" do
+      write("hyperdrive.yml", <<~YAML)
+        hyperdrive_version: ">= 0.9"
+        skills:
+          a:
+            gem: sidekiq
+            hyperdrive_version:
+              min: "0.9"
+      YAML
+      manifest, warnings = load_manifest
+      expect(manifest.skill_gate("a").to_h).to include(targets: ["*"], hyperdrive_version: nil)
+      expect(warnings.join).to include("unparsable hyperdrive_version:")
+    end
+
+    it "keeps a parseable top-level fence when the top-level gem: default is unusable" do
+      write("hyperdrive.yml", "gem:\n  none: [sqlite3]\nhyperdrive_version: \">= 0.9\"\n")
+      manifest, warnings = load_manifest
+      expect(manifest.skill_gate("unlisted").to_h).to include(targets: ["*"], hyperdrive_version: ">= 0.9")
+      expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
+      expect(warnings.join).not_to include("hyperdrive_version: default is unusable")
+    end
+
+    it "keeps the top-level gem: default when only the top-level fence is malformed" do
+      write("hyperdrive.yml", "gems:\n  - railties: \">= 7.2\"\nhyperdrive_version: garbage\n")
+      manifest, warnings = load_manifest
+      expect(manifest.skill_gate("a").to_h)
+        .to include(targets: ["railties"], versions: { "railties" => ">= 7.2" }, hyperdrive_version: nil)
+      expect(warnings.grep(/top-level hyperdrive_version: default is unusable/).size).to eq(1)
+      expect(warnings.join).not_to include("gem: default is unusable")
+    end
+  end
+
   describe "fail-open behavior" do
     it "warns and resolves ungated on a non-map entry, ignoring the defaults" do
       write("hyperdrive.yml", "gem: railties\nskills:\n  a: nope\n")
@@ -438,7 +498,7 @@ RSpec.describe Rails::Hyperdrive::GemManifest do
     it "warns and resolves ungated on a malformed member in the gem-wide defaults" do
       write("hyperdrive.yml", "gems:\n  - sidekiq: garbage\nskills:\n  a: {}\n")
       manifest, warnings = load_manifest
-      expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
+      expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
       expect(manifest.skill_gate("a").targets).to eq(["*"])
     end
 
@@ -459,10 +519,10 @@ RSpec.describe Rails::Hyperdrive::GemManifest do
       expect(warnings.grep(/unparsable hyperdrive_version:/).size).to eq(2)
     end
 
-    it "warns once and ignores unusable gem-wide defaults" do
+    it "warns once and ignores an unusable gem-wide gem: default" do
       write("hyperdrive.yml", "gem:\nskills:\n  a:\n    gem: sidekiq\n")
       manifest, warnings = load_manifest
-      expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
+      expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
       expect(manifest.skill_gate("unlisted").targets).to eq(["*"])
       expect(manifest.skill_gate("a").to_h).to include(targets: ["sidekiq"], versions: nil)
     end
@@ -470,15 +530,8 @@ RSpec.describe Rails::Hyperdrive::GemManifest do
     it "warns once and ignores a malformed gem: map in the gem-wide defaults" do
       write("hyperdrive.yml", "gem:\n  any: [sidekiq]\n  all: [devise]\nskills:\n  a: {}\n")
       manifest, warnings = load_manifest
-      expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
+      expect(warnings.grep(/top-level gem: default is unusable/).size).to eq(1)
       expect(manifest.skill_gate("a").targets).to eq(["*"])
-    end
-
-    it "drops every gem-wide default on an unusable top-level hyperdrive_version:" do
-      write("hyperdrive.yml", "gems:\n  - railties: \">= 7.2\"\nhyperdrive_version: garbage\n")
-      manifest, warnings = load_manifest
-      expect(warnings.grep(%r{top-level gem:/hyperdrive_version: defaults are unusable}).size).to eq(1)
-      expect(manifest.skill_gate("a").to_h).to include(targets: ["*"], versions: nil, hyperdrive_version: nil)
     end
 
     it "warns and reads nothing from malformed YAML" do

--- a/spec/hyperdrive/manifest_lint_spec.rb
+++ b/spec/hyperdrive/manifest_lint_spec.rb
@@ -1,0 +1,279 @@
+require "spec_helper"
+require "rails/hyperdrive/manifest_lint"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Rails::Hyperdrive::ManifestLint do
+  around { |ex| Dir.mktmpdir { |d| @dir = d; ex.run } }
+
+  def write(rel, body)
+    path = File.join(@dir, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, body)
+  end
+
+  def write_gemspec(metadata = {})
+    lines = metadata.map { |k, v| %(  s.metadata[#{k.inspect}] = #{v.inspect}\n) }
+    write("companion.gemspec", <<~RUBY)
+      Gem::Specification.new do |s|
+        s.name    = "companion"
+        s.version = "0.1.0"
+        s.summary = "fixture"
+        s.authors = ["fixture"]
+      #{lines.join}end
+    RUBY
+  end
+
+  def write_skill(rel, files: {})
+    write("skills/#{rel}/SKILL.md", "---\nname: #{File.basename(rel)}\ndescription: d\n---\n\n# skill\n")
+    files.each { |path, body| write("skills/#{rel}/#{path}", body) }
+  end
+
+  def write_guideline(name)
+    write("lib/companion/hyperdrive/guidelines/#{name}", "# guideline\n")
+  end
+
+  def problems(manifest)
+    write("hyperdrive.yml", manifest)
+    described_class.check(dir: @dir).problems
+  end
+
+  before do
+    write_gemspec
+    write_skill("alpha", files: { "references/notes.md" => "notes\n" })
+    write_guideline("jobs.md")
+  end
+
+  describe "a clean manifest" do
+    it "reports nothing for every accepted gating form" do
+      write("hyperdrive.yml", <<~YAML)
+        gems:
+          - railties: ">= 7.2"
+        hyperdrive_version: ">= 0.8"
+        skills:
+          alpha:
+            gems:
+              all:
+                - devise: ">= 4.9"
+                - pundit
+            hyperdrive_version: ">= 0.9"
+            conditional:
+              references/notes.md:
+                gem:
+                  any: [sidekiq, solid_queue]
+        guidelines:
+          jobs.md:
+            gem: "pg, mysql2"
+      YAML
+      result = described_class.check(dir: @dir)
+
+      expect(result.problems).to be_empty
+      expect(result.manifest).to eq("hyperdrive.yml")
+    end
+
+    it "reports nothing when the gem ships no manifest" do
+      result = described_class.check(dir: @dir)
+      expect(result.problems).to be_empty
+      expect(result.manifest).to be_nil
+    end
+
+    it "reads the manifest from the rails_hyperdrive_manifest path" do
+      write_gemspec("rails_hyperdrive_manifest" => "config/gating.yml")
+      write("config/gating.yml", "skills:\n  nope: {}\n")
+
+      result = described_class.check(dir: @dir)
+      expect(result.manifest).to eq("config/gating.yml")
+      expect(result.problems).to eq(["skills entry 'nope' names no shipped skill directory"])
+    end
+  end
+
+  describe "structure" do
+    it "fails on malformed YAML" do
+      expect(problems("skills: [unterminated\n").join).to include("malformed YAML")
+    end
+
+    it "fails on a non-map root" do
+      expect(problems("- a\n- b\n")).to eq(["root must be a YAML map"])
+    end
+
+    it "fails on a non-map skills: section" do
+      expect(problems("skills: nope\n").join).to include("skills: must be a map")
+    end
+
+    it "fails rather than raising on YAML the installer refuses to load" do
+      expect(problems("hyperdrive_version: 2026-01-01\n").join).to include("unreadable")
+      expect(problems("skills: &s {}\nguidelines: *s\n").join).to include("unreadable")
+    end
+
+    it "fails on a non-map entry" do
+      expect(problems("skills:\n  alpha: yes\n")).to eq(["skills entry 'alpha' must be a map of gating keys"])
+    end
+
+    it "passes on an empty manifest" do
+      expect(problems("")).to be_empty
+    end
+  end
+
+  describe "unknown keys" do
+    it "fails at the top level" do
+      expect(problems("skils:\n  alpha: {}\n").join).to include("top level: unknown key 'skils'")
+    end
+
+    it "fails in a skills entry" do
+      expect(problems("skills:\n  alpha:\n    only_if: sidekiq\n").join)
+        .to include("skills entry 'alpha': unknown key 'only_if'")
+    end
+
+    it "fails in a guidelines entry, which takes no conditional:" do
+      expect(problems("guidelines:\n  jobs.md:\n    conditional: {}\n").join)
+        .to include("guidelines entry 'jobs.md': unknown key 'conditional'")
+    end
+
+    it "fails in a conditional entry" do
+      manifest = "skills:\n  alpha:\n    conditional:\n      references/notes.md:\n" \
+                 "        gem: sidekiq\n        hyperdrive_version: \">= 0.9\"\n"
+      expect(problems(manifest).join)
+        .to include("skills entry 'alpha' conditional key 'references/notes.md': unknown key 'hyperdrive_version'")
+    end
+
+    it "points versions: and version: at the gem: member" do
+      manifest = "versions: \">= 7\"\nskills:\n  alpha:\n    gem: sidekiq\n    version: \">= 8\"\n"
+      expect(problems(manifest)).to contain_exactly(
+        a_string_including("top level: 'versions:' is not a gating key; put the requirement on the gem: member"),
+        a_string_including("skills entry 'alpha': 'version:' is not a gating key")
+      )
+    end
+
+    it "suggests hyperdrive_version: for its plural near-miss" do
+      expect(problems("hyperdrive_versions: \">= 0.9\"\n").join)
+        .to include("unknown key 'hyperdrive_versions' (did you mean 'hyperdrive_version'?)")
+    end
+  end
+
+  describe "gating values" do
+    it "fails on a bare gem: map, which is never read as name: requirement" do
+      expect(problems("skills:\n  alpha:\n    gem:\n      railties: \">= 7.0\"\n").join)
+        .to include("skills entry 'alpha': gem: must name a gem")
+    end
+
+    it "fails on an unparsable member requirement" do
+      expect(problems("skills:\n  alpha:\n    gems:\n      - sidekiq: garbage\n").join)
+        .to include("skills entry 'alpha': gem: must name a gem")
+    end
+
+    it "fails on an unparsable hyperdrive_version:" do
+      expect(problems("skills:\n  alpha:\n    hyperdrive_version:\n      min: \"0.9\"\n").join)
+        .to include("skills entry 'alpha': hyperdrive_version: must be a version requirement")
+    end
+
+    it "fails when one map carries both gem: and gems:" do
+      expect(problems("gem: railties\ngems: sidekiq\n").join)
+        .to include("top level: gem: and gems: are aliases; keep only one")
+    end
+
+    it "fails on a \"*\" pair key carrying a requirement" do
+      expect(problems("skills:\n  alpha:\n    gems:\n      - sidekiq\n      - \"*\": \">= 1\"\n").join)
+        .to include("a version requirement on '*' is meaningless")
+    end
+
+    it "fails on a \"*\" inside all:" do
+      expect(problems("skills:\n  alpha:\n    gems:\n      all: [devise, \"*\"]\n").join)
+        .to include("'*' in all: is always satisfied")
+    end
+  end
+
+  describe "keys naming nothing shipped" do
+    it "fails on a skills key with no shipped directory" do
+      expect(problems("skills:\n  beta:\n    gem: sidekiq\n"))
+        .to eq(["skills entry 'beta' names no shipped skill directory"])
+    end
+
+    it "fails on a guidelines key with no shipped file" do
+      expect(problems("guidelines:\n  models.md:\n    gem: sidekiq\n"))
+        .to eq(["guidelines entry 'models.md' names no shipped guideline"])
+    end
+
+    it "matches a paired skill by its content-directory relpath" do
+      write_gemspec("rails_hyperdrive_skill_templates_dir" => "templates")
+      write("templates/alpha/SKILL.md.erb", "---\nname: alpha\ndescription: d\n---\n")
+
+      expect(problems("skills:\n  alpha:\n    gem: sidekiq\n")).to be_empty
+    end
+  end
+
+  describe "conditional entries" do
+    it "fails on a non-map conditional:" do
+      expect(problems("skills:\n  alpha:\n    conditional: nope\n").join)
+        .to include("conditional: must be a map of supporting-file path to a gating map")
+    end
+
+    it "fails on a key naming SKILL.md" do
+      expect(problems("skills:\n  alpha:\n    conditional:\n      SKILL.md:\n        gem: sidekiq\n").join)
+        .to include("conditional key 'SKILL.md': the entry's own gem: gates the whole skill")
+    end
+
+    it "fails on a key naming no shipped supporting file" do
+      expect(problems("skills:\n  alpha:\n    conditional:\n      references/gone.md:\n        gem: sidekiq\n").join)
+        .to include("conditional key 'references/gone.md': names no shipped supporting file")
+    end
+
+    it "matches a template-side supporting file by its shipped *.md.erb path" do
+      write_gemspec("rails_hyperdrive_skill_templates_dir" => "templates")
+      write("templates/alpha/SKILL.md.erb", "---\nname: alpha\ndescription: d\n---\n")
+      write("templates/alpha/references/tips.md.erb", "tips\n")
+
+      manifest = "skills:\n  alpha:\n    conditional:\n      references/tips.md.erb:\n        gem: sidekiq\n"
+      expect(problems(manifest)).to be_empty
+    end
+
+    it "fails on a non-map entry and on one without gem:" do
+      manifest = <<~YAML
+        skills:
+          alpha:
+            conditional:
+              references/notes.md: yes
+      YAML
+      expect(problems(manifest).join).to include("conditional key 'references/notes.md': must be a map with gem:")
+
+      manifest = "skills:\n  alpha:\n    conditional:\n      references/notes.md: {}\n"
+      expect(problems(manifest).join).to include("conditional key 'references/notes.md': gem: is required")
+    end
+  end
+
+  it "reports every problem rather than stopping at the first" do
+    manifest = <<~YAML
+      gem:
+        railties: ">= 7.0"
+      skills:
+        beta:
+          versions: ">= 1"
+      guidelines:
+        jobs.md:
+          hyperdrive_version: garbage
+    YAML
+
+    expect(problems(manifest)).to contain_exactly(
+      a_string_including("top level: gem: must name a gem"),
+      a_string_including("skills entry 'beta' names no shipped skill directory"),
+      a_string_including("skills entry 'beta': 'versions:' is not a gating key"),
+      a_string_including("guidelines entry 'jobs.md': hyperdrive_version: must be a version requirement")
+    )
+  end
+
+  describe "gemspec resolution" do
+    it "raises when the directory has no gemspec" do
+      FileUtils.rm(File.join(@dir, "companion.gemspec"))
+      expect { described_class.check(dir: @dir) }
+        .to raise_error(described_class::Error, /no \.gemspec found/)
+    end
+
+    it "accepts an explicit gemspec path" do
+      write("hyperdrive.yml", "skills:\n  beta: {}\n")
+      nested = File.join(@dir, "elsewhere")
+      FileUtils.mkdir_p(nested)
+
+      result = described_class.check(gemspec: File.join(@dir, "companion.gemspec"), dir: nested)
+      expect(result.problems).to eq(["skills entry 'beta' names no shipped skill directory"])
+    end
+  end
+end

--- a/spec/hyperdrive/skill_tasks_spec.rb
+++ b/spec/hyperdrive/skill_tasks_spec.rb
@@ -3,7 +3,7 @@ require "rake"
 require "fileutils"
 require "tmpdir"
 
-RSpec.describe "hyperdrive:skills rake tasks" do
+RSpec.describe "hyperdrive rake tasks" do
   around { |ex| Dir.mktmpdir { |d| @dir = d; ex.run } }
 
   before do
@@ -74,6 +74,25 @@ RSpec.describe "hyperdrive:skills rake tasks" do
     expect do
       expect { invoke("hyperdrive:skills:check") }.to raise_error(SystemExit)
     end.to output(%r{raw ERB: .*skills/paired/references/notes\.md\.erb}).to_stderr
+  end
+
+  describe "hyperdrive:manifest:check" do
+    it "passes on a clean manifest" do
+      write("hyperdrive.yml", "skills:\n  paired:\n    gem: sidekiq\n")
+      expect { invoke("hyperdrive:manifest:check") }.to output(%r{hyperdrive\.yml is clean}).to_stdout
+    end
+
+    it "passes when the gem ships no manifest" do
+      expect { invoke("hyperdrive:manifest:check") }.to output(/nothing to lint/).to_stdout
+    end
+
+    it "fails listing every problem" do
+      write("hyperdrive.yml", "skills:\n  missing:\n    version: \">= 1\"\n")
+
+      expect do
+        expect { invoke("hyperdrive:manifest:check") }.to raise_error(SystemExit)
+      end.to output(/names no shipped skill directory.*'version:' is not a gating key/m).to_stderr
+    end
   end
 
   it "accepts an explicit gemspec path argument" do


### PR DESCRIPTION
A companion's `hyperdrive_version:` fence is the sanctioned way to say "this manifest needs a newer installer" — but an older installer that couldn't parse the entry's `gem:` value discarded the fence along with the gate and installed the artifact everywhere, unconstrained. That is the exact case the fence exists to cover, and it failed precisely when the manifest used syntax the running installer didn't know yet.

The fence is now resolved before the gate. Fail-open reads "install ungated unless fenced out": an unusable `gem:` still warns and installs ungated, but a parseable fence on that entry — or the gem-wide default, when the entry names none — still applies. The two gem-wide defaults are independent too: an unusable `gem:` default no longer drops a parseable fence, and a malformed fence no longer drops a usable `gem:` default; each warns for its own axis. An entry whose own `hyperdrive_version:` is unparsable stays ungated and unfenced, since substituting the gem-wide fence would apply a constraint that entry never asked for.

The installer stays permissive by design, so that a manifest written for a newer schema never blocks an install. The cost is that a key typo — `version:` for a member requirement, `hyperdrive_versions:` for the fence — silently drops the constraint with no signal anywhere. `rake hyperdrive:manifest:check` is the answer on the author's side, joining `hyperdrive:skills:*` on the companion-repo rake surface with the same optional gemspec-path argument. It is strict where the installer is permissive: unknown keys at the top level, in `skills:`/`guidelines:` entries, and in `conditional:` entries; any `gem:`/`gems:` or `hyperdrive_version:` value the installer cannot parse; and `skills:`/`guidelines:`/`conditional:` keys naming nothing the gem ships. The retired `versions:` key and its `version:` near-miss get pointed messages. The governing principle is that a manifest which lints clean draws no gating warning at install time. Fence *satisfaction* is deliberately not linted — that depends on which installer an app runs, not on the manifest.

Two supporting changes: gemspec-and-metadata-dir resolution moves out of `CanonicalSkillRender` into a shared `GemspecLocator` so both companion-repo tasks use one implementation, and discovery's `skill_paths`/`guideline_paths` become public so the lint enumerates shipped artifacts through the same code the runtime stale-key warning uses rather than a second copy of those conventions.

Documentation for the new rake task lands separately.