### PR TITLE
docs: correct companion-gem contract docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ skills/<name>/SKILL.md                                 # skill (dir-per-skill, m
 lib/<gem_name>/hyperdrive/guidelines/<name>.md         # guideline (flat file)
 ```
 
-Top-level `skills/` is the recommended home for skill content: it is the tool-agnostic face of your gem, readable by skills.sh and plain git-clone consumers as well as hyperdrive, and it is scanned by default. `lib/<gem_name>/hyperdrive/` is the hyperdrive-specific root: guidelines, and ERB skill templates (`SKILL.md.erb`, which must stay out of `skills/` so raw ERB never reaches generic consumers). Plain skills shipped under it remain scanned as well.
+`<gem_name>` is your gem's name exactly as published, dashes and all — `rails-hyperdrive-sidekiq` ships guidelines under `lib/rails-hyperdrive-sidekiq/hyperdrive/guidelines/`, not `lib/rails/hyperdrive/sidekiq/`.
+
+Top-level `skills/` is the recommended home for skill content: it is the tool-agnostic face of your gem, readable by skills.sh and plain git-clone consumers as well as hyperdrive, and it is scanned by default once your gem has opted in (below). `lib/<gem_name>/hyperdrive/` is the hyperdrive-specific root: guidelines, and ERB skill templates (`SKILL.md.erb`, which must stay out of `skills/` so raw ERB never reaches generic consumers). Plain skills shipped under it remain scanned as well.
 
 Frontmatter is pure skills.sh: only `name` and `description` are read, so a skill repo's content integrates without modification:
 
@@ -221,6 +223,8 @@ Shipping a `hyperdrive.yml` (or declaring `rails_hyperdrive_manifest`) opts your
 ```ruby
 spec.metadata["rails_hyperdrive_targets"] = "sidekiq"
 ```
+
+Companion repos get author-side CI checks by adding `require "rails/hyperdrive/skill_tasks"` to the `Rakefile`: `rake hyperdrive:skills:check` keeps generated skill content in step with its templates, and `rake hyperdrive:manifest:check` lints `hyperdrive.yml` strictly.
 
 [docs/COMPANION_GEMS.md](docs/COMPANION_GEMS.md) has the full contract: multi-target artifacts, multi-file skills, per-file gem gating, ERB-templated content, the template/content paired layout that also serves `npx skills` and git-clone consumers, and the collision and dedup rules.
 

--- a/docs/COMPANION_GEMS.md
+++ b/docs/COMPANION_GEMS.md
@@ -12,14 +12,20 @@ A companion gem ships artifacts under:
 <gem-source>/lib/<gem_name>/hyperdrive/guidelines/<name>.md         # guideline (flat file)
 ```
 
-Top-level `skills/` is the recommended home for skill content: it is the public, tool-agnostic face of the gem, matching what [skills.sh](https://www.skills.sh) and plain git-clone consumers expect, and it is scanned by default; no metadata key is needed. `lib/<gem_name>/hyperdrive/` is the hyperdrive-specific root: it holds guidelines and is the default home for ERB skill templates (`SKILL.md.erb` must stay here, so raw ERB never reaches generic `skills/` consumers). Plain static skills shipped under it remain scanned indefinitely, so published companions keep working unchanged; prefer top-level `skills/` for new ones.
+`<gem_name>` is the gem's name exactly as published, dashes and all — Ruby's dash-to-slash require convention does not apply. A gem named `rails-hyperdrive-sidekiq` ships guidelines under `lib/rails-hyperdrive-sidekiq/hyperdrive/guidelines/`, **not** `lib/rails/hyperdrive/sidekiq/guidelines/`. A file at the dash-to-slash path is silently never discovered: guidelines have no override root and no fallback, so nothing can warn about it.
+
+Top-level `skills/` is the recommended home for skill content: it is the public, tool-agnostic face of the gem, matching what [skills.sh](https://www.skills.sh) and plain git-clone consumers expect, and it is scanned by default once the gem has opted in (below); no additional metadata key is needed. `lib/<gem_name>/hyperdrive/` is the hyperdrive-specific root: it holds guidelines and is the default home for ERB skill templates (`SKILL.md.erb` must stay here, so raw ERB never reaches generic `skills/` consumers). Plain static skills shipped under it remain scanned indefinitely, so published companions keep working unchanged; prefer top-level `skills/` for new ones.
 
 ### The companion opt-in gate
 
-Discovery walks the entire bundle, and many gemspecs package files via `git ls-files`, so an ordinary non-companion gem can ship a contributor-facing `skills/` directory by accident. A gem's artifacts are therefore only scanned when one of two things is true:
+Discovery walks the entire bundle, and many gemspecs package files via `git ls-files`, so an ordinary non-companion gem can ship a contributor-facing `skills/` directory by accident. A gem's artifacts are therefore only scanned when one of a closed set of signals is present:
 
-- the gem itself carries hyperdrive-specific configuration: artifacts under the `lib/<gem_name>/hyperdrive/` convention path, a `hyperdrive.yml` manifest at the gem root (below), or any `rails_hyperdrive_*` gemspec metadata key, or
-- the app names the gem in the `enabled:` list of `.hyperdrive/lock.yml`.
+- artifacts under the `lib/<gem_name>/hyperdrive/` convention path — skills or guidelines;
+- a `hyperdrive.yml` manifest at the gem root (below);
+- one of the gemspec metadata keys `rails_hyperdrive_skills_dir`, `rails_hyperdrive_skill_templates_dir`, `rails_hyperdrive_targets`, or `rails_hyperdrive_manifest` — any non-empty value counts, even one discovery later rejects (a `..` segment, say), since declaring the key at all signals intent;
+- the app naming the gem in the `enabled:` list of `.hyperdrive/lock.yml`.
+
+`rails_hyperdrive_artifacts` is deliberately not in that set: it is a presentational hint read by `hyperdrive:discover` (below) and never an opt-in signal.
 
 An un-opted gem shipping `skills/*/SKILL.md` never auto-installs: `hyperdrive:init`/`hyperdrive:sync` surface it with a pointer to the `enabled:` list instead.
 
@@ -57,6 +63,10 @@ A plain skills.sh SKILL.md installs with zero warnings, and an adopted skill rep
 
 `name:` is the artifact's identity, not a label. It is what the installer writes to disk (`.claude/skills/<name>/SKILL.md`, `.claude/hyperdrive/guidelines/<name>.md`). Keep it equal to the file or directory stem: if the two disagree the install still succeeds, but the artifact lands under `name:`. Within one gem, two artifacts of the same type declaring the same `name:` collapse to a single installed file; which one survives is not a guarantee to build on, so give each a distinct `name:`.
 
+`--` is reserved inside `name:`. It is the collision-postfix separator: colliding artifacts install as `<name>--<source_gem>`, and the installer parses an installed name back at its **first** `--` to recover the base name, which drives `disabled:` matching, orphan reporting, and the sha-gated delete. A `name:` containing `--` makes that parse ambiguous. Avoid `--` in the companion gem's own name for the same reason — the gem name is what lands in the postfix.
+
+Renaming a skill directory or its `name:` is a breaking change for apps that already installed it. On their next `hyperdrive:init`/`hyperdrive:sync` the new name installs fresh and the old one is deleted — but only when the old copy is unedited, its source gem is still bundled, and that gem lost no artifact to a discovery skip in the same run; a locally edited copy is reported and left for the user to delete by hand. The additive top-up after `bundle install` removes nothing, so until a sync runs the skill sits under both names. Renaming the directory also detaches its gating, since `skills:` entries are keyed by directory path: the old manifest key names no shipped directory and starts warning.
+
 ## The gem-root manifest
 
 Gating (which bundles an artifact installs into) is declared in a `hyperdrive.yml` at the gem root, or at the path named by a `rails_hyperdrive_manifest` gemspec metadata key (relative to the gem root; a value containing `..` segments, or a blank value, falls back to the conventional path). Every key is optional, and no manifest (or an empty one) means every artifact installs universally:
@@ -69,7 +79,7 @@ skills:                  # per-skill entries, keyed by the skill dir's path rela
   layered-rails:
     gems:
       - railties: ">= 8.0"
-    hyperdrive_version: ">= 0.8"
+    hyperdrive_version: ">= 0.7"
     conditional:         # per-file supporting-file gating — see below
       references/gems/alba.md: { gem: alba }
 guidelines:              # per-guideline entries, keyed by filename (extension included)
@@ -88,7 +98,8 @@ Entries are keyed by path, never by the skill's `name:`: a skill entry's key is 
 
 - an unreadable or non-map manifest is warned about and treated as absent;
 - a non-map `skills:`/`guidelines:` section is warned about and ignored;
-- a malformed entry (non-map value, unusable `gem:`, unparsable `hyperdrive_version:`) is warned about and the artifact installs **ungated** (the gem-wide defaults are not applied either);
+- a malformed entry (a non-map value, or an unusable `gem:`) is warned about and the artifact installs **ungated**, the gem-wide `gem:` default dropped along with it — though a resolvable fence still applies (below);
+- an entry whose own `hyperdrive_version:` is unparsable is warned about and installs ungated **and** unfenced;
 - an entry whose key matches no shipped skill directory or guideline is warned about and ignored; this is the staleness signal when a skill dir is renamed out from under its gating.
 
 ### Version requirements
@@ -145,7 +156,7 @@ Draw the listed targets from the gem's own `hyperdrive_targets` (below): the gem
 skills:
   turbo-morph:
     gem: [turbo-rails, hotwire-rails]
-    hyperdrive_version: ">= 0.8"
+    hyperdrive_version: ">= 0.7"
 ```
 
 The fence is matched against the running installer's own version, never against the bundle. That is what makes it a separate key: `gem:` is any-match across its targets, so adding `rails-hyperdrive` to the list would read as "turbo-rails **or** rails-hyperdrive", not "turbo-rails **and** a new enough installer".
@@ -153,10 +164,12 @@ The fence is matched against the running installer's own version, never against 
 An unsatisfied fence skips the artifact — gating working, exactly like a `gem:` gate matching nothing — and reports it, at `hyperdrive:init`/`hyperdrive:sync` and in `bundle install` output:
 
 ```
-skill 'turbo-morph' (from rails-hyperdrive-turbo) requires rails-hyperdrive >= 0.8 (this is 0.6.0); upgrade rails-hyperdrive to install it
+skill 'turbo-morph' (from rails-hyperdrive-turbo) requires rails-hyperdrive >= 0.7 (this is 0.6.0); upgrade rails-hyperdrive to install it
 ```
 
-The fence is decided before `gem:`, so a fenced-out artifact reports the upgrade and nothing about its targets — including in apps that bundle none of them. Skipped means not installed, not uninstalled: a copy already on disk from an earlier release stays exactly where it is, reported as an orphan. A malformed `hyperdrive_version:` fails open like any other unreadable gating — it is warned about and the artifact installs, unfenced.
+The fence is decided before `gem:`, so a fenced-out artifact reports the upgrade and nothing about its targets — including in apps that bundle none of them. Skipped means not installed, not uninstalled: a copy already on disk from an earlier release stays exactly where it is, reported as an orphan.
+
+Resolving the fence first is also what makes it survive gating the installer cannot read. A malformed `gem:`/`gems:` still falls open to an ungated install — but a parseable `hyperdrive_version:` alongside it keeps applying, per entry and gem-wide, where the two default axes fail independently (an unusable default `gem:` never drops a parseable default fence). Fail-open therefore reads "install ungated **unless fenced out**", so a manifest written in a value shape an older installer cannot parse is fenced out of that installer rather than installing everywhere unconstrained. The one exception is the fence being the unparsable part itself: an entry with an unreadable `hyperdrive_version:` installs ungated and unfenced, because inheriting the gem-wide fence would impose a constraint that entry never asked for.
 
 Reach for the fence when content depends on an installer capability (a manifest key, a discovery behavior) rather than on a library in the app. Note what it cannot do: releases predating the key ignore it as an unknown manifest key, so it constrains only installers that understand it, and it has no effect on `hyperdrive:discover`, which is version-blind.
 
@@ -186,11 +199,13 @@ A malformed condition **fails open**: the file installs unconditionally and the 
 
 ### ERB-templated markdown
 
-A file named `*.md.erb` in a skill directory is rendered at install time and lands as plain `.md` (the `.erb` suffix is dropped). `SKILL.md.erb` defines a skill exactly like `SKILL.md`; its frontmatter is parsed from the rendered output. Templates can call exactly three helpers; no other Ruby context is available:
+A file named `*.md.erb` in a skill directory is rendered at install time and lands as plain `.md` (the `.erb` suffix is dropped). `SKILL.md.erb` defines a skill exactly like `SKILL.md`; its frontmatter is parsed from the rendered output. Hyperdrive provides three helpers, and they are the only API a template may rely on:
 
 - `gem?("name")` / `gem?("name", ">= 2.0")`: is the gem bundled (at a satisfying version)?
 - `any_gem?("a", "b", …)`: is any of these bundled?
 - `gem_version("name")`: the resolved version as a String, or `nil`.
+
+Nothing beyond those three is a contract — but nothing is blocked either. A template is plain ERB over an ordinary Ruby binding, not a sandbox: it can reach anything Ruby can, and it runs with the developer's own privileges at discovery time — during `hyperdrive:init`/`hyperdrive:sync`, on every `bundle install` through the bundler plugin, and when the MCP server answers `describe_app`. Enabling a companion trusts its templates exactly like its `lib/` code.
 
 ```erb
 Use `bundle exec sidekiq` (you run Sidekiq <%= gem_version("sidekiq") || "any version" %>).
@@ -210,9 +225,10 @@ Gated files appear and disappear as the bundle changes: `hyperdrive:init`/`hyper
 Generic consumers (`npx skills`, people browsing a git clone) need a static `skills/<name>/SKILL.md` with its supporting files beside it; hyperdrive wants the `SKILL.md.erb` master. Neither file can live in the other's directory: a static `SKILL.md` beside the template would take precedence over it, and raw ERB in `skills/` would be copied verbatim by tools that don't render it. Pairing splits the skill across two directories:
 
 ```
-skills/<name>/SKILL.md                            # content dir: generated static face…
-skills/<name>/references/…                        # …plus ALL supporting files
-lib/<gem_name>/hyperdrive/skills/<name>/SKILL.md.erb   # template dir: the master, and nothing else
+skills/<name>/SKILL.md                                  # content dir: generated static face…
+skills/<name>/references/…                              # …plus every static supporting file
+lib/<gem_name>/hyperdrive/skills/<name>/SKILL.md.erb    # template dir: the master…
+lib/<gem_name>/hyperdrive/skills/<name>/references/…    # …plus any supporting *.md.erb templates
 ```
 
 with gemspec metadata pointing the two roots apart:
@@ -224,9 +240,11 @@ spec.metadata["rails_hyperdrive_skills_dir"] = "skills"
 spec.metadata["rails_hyperdrive_skill_templates_dir"] = "lib/<gem_name>/hyperdrive/skills"
 ```
 
-A skill dir holding a static `SKILL.md` pairs with the template dir at the **same relative path** under the templates root (nested layouts like `skills/<category>/<name>/` pair too). The pair is one skill: hyperdrive renders the **template** against the app's bundle and takes the supporting files from the **content dir**. It never reads the static `SKILL.md`, which exists for consumers that can't inspect a bundle. A template dir with no matching content dir, or a content dir with no matching template, is an ordinary standalone skill, so pairing is strictly opt-in. Keep the template dir down to `SKILL.md.erb` alone: anything else in it is ignored with a warning, since the content dir is the single source of truth for supporting files. A template that fails to render skips the skill (the static file is deliberately not a fallback, because falling back would silently un-condition the skill).
+A skill dir holding a static `SKILL.md` pairs with the template dir at the **same relative path** under the templates root (nested layouts like `skills/<category>/<name>/` pair too). The pair is one skill: hyperdrive renders the **template** against the app's bundle and takes the supporting files from the **content dir**. It never reads the static `SKILL.md`, which exists for consumers that can't inspect a bundle. Pairing is strictly opt-in: a content dir with no matching template is an ordinary standalone skill, and so is a template dir with no matching content dir — but only when that template dir sits under a root discovery actually enumerates, namely the convention path (which is also the default templates root), top-level `skills/`, or the `rails_hyperdrive_skills_dir` override. A custom `rails_hyperdrive_skill_templates_dir` is consulted for pairing alone and never enumerated, so a template-only skill placed there is silently dropped; keep standalone template skills under a scanned skills root. A template that fails to render skips the skill (the static file is deliberately not a fallback, because falling back would silently un-condition the skill).
 
-### Generating and checking the static face
+The template dir holds templates and nothing else: `SKILL.md.erb` plus any supporting `*.md.erb`, which render against the app's bundle and install as plain `.md` alongside the rest of the skill. Any other file in it is ignored with a warning — static supporting files are the content dir's to ship. A template-side file **owns** its rendered target path: a same-named file in the content dir never installs, whether the template renders, is gated out by `conditional:`, or fails to render, since falling back to the static face would silently un-condition the file. A supporting `*.md.erb` under a public skills root still renders, but warns and points you at the template dir: generic consumers copy it verbatim and get raw ERB.
+
+### Author-side rake tasks
 
 The static `SKILL.md` is generated, not hand-written. In the companion repo's `Rakefile`:
 
@@ -234,10 +252,15 @@ The static `SKILL.md` is generated, not hand-written. In the companion repo's `R
 require "rails/hyperdrive/skill_tasks"
 ```
 
-- `rake hyperdrive:skills:render` renders each `SKILL.md.erb` to its paired static `SKILL.md` using the **canonical** binding: `gem?`/`any_gem?` always true (even with a version requirement), `gem_version` always `nil`. That is the fail-open, everything-included face for consumers whose bundle can't be inspected. Templates that interpolate `gem_version` must handle `nil` (e.g. `<%= gem_version("sidekiq") || "(any version)" %>`).
-- `rake hyperdrive:skills:check` renders in memory and fails, listing any stale static file. Run it in CI so the generated face never drifts from its template.
+- `rake hyperdrive:skills:render` renders each `SKILL.md.erb` to its paired static `SKILL.md`, and each supporting `*.md.erb` to its own face in the same content dir, using the **canonical** binding: `gem?`/`any_gem?` always true (even with a version requirement), `gem_version` always `nil`. Templates that interpolate `gem_version` must handle `nil` (e.g. `<%= gem_version("sidekiq") || "(any version)" %>`).
+- `rake hyperdrive:skills:check` renders in memory and fails, listing any stale static file; it also fails on any `*.md.erb` found under a public skills root.
+- `rake hyperdrive:manifest:check` lints `hyperdrive.yml` where the installer is deliberately permissive, and fails on: unknown keys at every level (top level, `skills:`/`guidelines:` entries, `conditional:` entries), any `gem:`/`gems:`/`hyperdrive_version:` value the installer cannot parse or would only accept with a warning, and entry keys naming nothing the gem ships — with the retired `versions:` and its `version:` near-miss called out by name. A manifest that lints clean draws no gating warning at install time.
 
-Both read the single `*.gemspec` in the working directory (pass an explicit path as a task argument otherwise: `rake "hyperdrive:skills:render[path/to/name.gemspec]"`) and require rails-hyperdrive only as a development dependency, with no Rails app involved. The generated file is the rendered template verbatim; with gating in the manifest, the static face is already the pristine skills.sh view. Template-using companions require the rails-hyperdrive release that ships pairing. Unlike discovery, which quietly ignores a `..` segment in `rails_hyperdrive_skills_dir` or `rails_hyperdrive_skill_templates_dir`, these tasks fail on one (`gemspec metadata <key> must not contain '..' segments`).
+Because every predicate reads true in the canonical binding, the render takes the **first** branch: an `if`/`elsif`/`else` chain contributes only its `if` body to the static face, and an `unless gem?(...)` body vanishes from it entirely — and `skills:check` byte-blesses whatever comes out, so nothing catches the loss. Write templates meant for pairing as independent, additive `if gem?(...)` blocks; never wrap a bundle predicate in `else`, `elsif`, or `unless`.
+
+Run both `check` tasks in CI: one keeps the generated face in step with its templates, the other keeps the manifest inside the schema.
+
+All three tasks read the single `*.gemspec` in the working directory (pass an explicit path as a task argument otherwise: `rake "hyperdrive:skills:render[path/to/name.gemspec]"`) and require rails-hyperdrive only as a development dependency, with no Rails app involved. The generated file is the rendered template verbatim; with gating in the manifest, the static face is already the pristine skills.sh view. The two `skills:` tasks are stricter than discovery about their roots: where discovery quietly ignores a `..` segment in `rails_hyperdrive_skills_dir` or `rails_hyperdrive_skill_templates_dir`, they fail on one (`gemspec metadata <key> must not contain '..' segments`).
 
 ## Discovery never raises
 

--- a/lib/rails/hyperdrive/skill_template.rb
+++ b/lib/rails/hyperdrive/skill_template.rb
@@ -3,8 +3,9 @@ require "erb"
 module Rails
   module Hyperdrive
     # Renders a skill's *.md.erb sources against the app's resolved bundle.
-    # The template binding is sealed: exactly three helpers over the resolved
-    # {gem name => Gem::Version} map, no app context, no arbitrary lookup.
+    # The three helpers are the only supported template API, but the binding is
+    # an ordinary object rather than a sandbox: a template runs arbitrary Ruby
+    # with the privileges of whoever triggered discovery.
     module SkillTemplate
       class Context
         def initialize(resolved)
@@ -31,9 +32,10 @@ module Rails
         end
       end
 
-      # Fail-open binding for the canonical render: every gem reads as present
-      # at any requested version, so the output includes every conditional
-      # branch. There is no bundle to resolve against, so gem_version is nil.
+      # Canonical render binding: every gem reads as present at any requested
+      # version, so an if/elsif/else contributes only its first branch and
+      # templates meant for this render must use additive if blocks. There is
+      # no bundle to resolve against, so gem_version is nil.
       class CanonicalContext
         def gem?(_name, _requirement = nil)
           true


### PR DESCRIPTION
Corrects nine inaccuracies in the companion-gem contract docs and brings them in line with the current behavior of fence-first gating, the rename/stale-dest sweep, and support-file templates. No behavior changes — the only source edit replaces two comments in `skill_template.rb` that described the template binding incorrectly.

The substantive corrections: `<gem_name>` in the convention paths is the gem's literal name with dashes preserved, and a guideline placed at the dash-to-slash path is silently never discovered; the opt-in gate is a closed list of signals, not "any `rails_hyperdrive_*` metadata key" (`rails_hyperdrive_artifacts` is a `hyperdrive:discover` hint and opts nothing in); `--` is reserved in artifact and gem names because it is the collision-postfix separator that `disabled:` matching and uninstall bookkeeping parse against; ERB templates are not sandboxed — the three helpers are the supported API, but templates are plain ERB over an ordinary binding and run with the developer's privileges during init/sync, every `bundle install`, and `describe_app`; the canonical render makes every bundle predicate true, so an `if`/`elsif`/`else` chain contributes only its first branch to the generated static face and pairing templates must use independent additive `if gem?(...)` blocks; and a custom `rails_hyperdrive_skill_templates_dir` is consulted only for pairing, so a template-only skill placed there is dropped rather than installed standalone.

Also documents what recent work changed: the fence resolves before the gate and survives a malformed `gem:`, so fail-open reads "install ungated unless fenced out"; renaming a skill dir or its `name:` is a breaking change for installed apps, with the old copy removed on the next sync only when unedited; template dirs may now ship supporting `*.md.erb` alongside `SKILL.md.erb`, and a template-side file owns its target path; and `rake hyperdrive:manifest:check` is documented next to the skills render/check tasks.

Example fences are normalized to `">= 0.7"`.