### PR TITLE
test: pin untested branches in the unit suite

### DIFF
--- a/spec/bundler_hyperdrive/plugins_spec.rb
+++ b/spec/bundler_hyperdrive/plugins_spec.rb
@@ -4,12 +4,15 @@ require_relative "../../bundler-hyperdrive/lib/bundler/hyperdrive"
 
 RSpec.describe "bundler-hyperdrive/plugins.rb" do
   # `load`, not `require_relative`: the file may already be in $LOADED_FEATURES.
-  def registered_hook
-    captured = nil
-    allow(Bundler::Plugin).to receive(:add_hook) { |name, &block| captured = [name, block] }
-    load File.expand_path("../../bundler-hyperdrive/plugins.rb", __dir__)
-    captured
-  end
+  # Loaded once for the group — each `load` recompiles the file and resets its
+  # coverage counters to whatever that copy happened to run.
+  captured = nil
+  original_add_hook = Bundler::Plugin.method(:add_hook)
+  Bundler::Plugin.define_singleton_method(:add_hook) { |name, &block| captured = [name, block] }
+  load File.expand_path("../../bundler-hyperdrive/plugins.rb", __dir__)
+  Bundler::Plugin.define_singleton_method(:add_hook, original_add_hook)
+
+  let(:registered_hook) { captured }
 
   it "registers the after-install-all hook" do
     name, block = registered_hook

--- a/spec/hyperdrive/ancestor_locator_spec.rb
+++ b/spec/hyperdrive/ancestor_locator_spec.rb
@@ -259,4 +259,64 @@ RSpec.describe Rails::Hyperdrive::AncestorLocator do
       )).to be_nil
     end
   end
+
+  describe "resolving the bundle itself" do
+    let(:relpath) { "lib/rails-hyperdrive-x/hyperdrive/skills/jobs/SKILL.md" }
+    let(:template) { "---\nname: jobs\ndescription: d\n---\n\n<%= gem?(\"rspec-core\") ? \"bundled\" : \"absent\" %>\n" }
+    let(:rendered) { "---\nname: jobs\ndescription: d\n---\n\nbundled\n" }
+
+    # The pipeline never injects a bundle map, so this is the path it takes.
+    it "renders an .md.erb twin against the live bundle when no caller supplies a map" do
+      ship("#{relpath}.erb", template)
+
+      body = described_class.locate(
+        kind: "skill", relpath: relpath,
+        lock_entry: lock_entry(kind: "skill", sha: sha(rendered)), gem_paths: [home]
+      )
+
+      expect(body).to eq(rendered)
+    end
+
+    it "returns nil when the bundle cannot be resolved" do
+      ship("#{relpath}.erb", template)
+      allow(::Bundler).to receive(:load).and_raise(::Bundler::GemfileNotFound)
+
+      body = described_class.locate(
+        kind: "skill", relpath: relpath,
+        lock_entry: lock_entry(kind: "skill", sha: sha(rendered)), gem_paths: [home]
+      )
+
+      expect(body).to be_nil
+    end
+  end
+
+  describe "a lock entry it cannot read" do
+    it "reads as unavailable rather than raising out of locate" do
+      entry = double("entry", source_gem: "rails-hyperdrive-x", source_version: "1.0.0")
+      allow(entry).to receive(:source_sha).and_raise(RuntimeError, "corrupt entry")
+
+      expect(
+        described_class.locate(kind: "guideline", relpath: guideline_relpath,
+          lock_entry: entry, gem_paths: [home])
+      ).to be_nil
+    end
+
+    it "reads as unavailable rather than raising out of locate_recorded_ancestor" do
+      entry = double("entry", ancestor?: true, kind: "guideline", path: "x.md")
+      allow(entry).to receive(:ancestor_relpath).and_raise(RuntimeError, "corrupt entry")
+
+      expect(described_class.locate_recorded_ancestor(entry, gem_paths: [home])).to be_nil
+    end
+
+    it "rebuilds without a name rewrite when the destination cannot be read" do
+      relpath = "lib/rails-hyperdrive-x/hyperdrive/skills/jobs/SKILL.md"
+      shipped = "---\nname: jobs\ndescription: d\n---\n\n# jobs\n"
+      ship(relpath, shipped)
+      entry = double("entry", ancestor?: true, kind: "skill", ancestor_gem: "rails-hyperdrive-x",
+        ancestor_version: "1.0.0", ancestor_sha: sha(shipped), ancestor_relpath: relpath)
+      allow(entry).to receive(:path).and_raise(RuntimeError, "corrupt entry")
+
+      expect(described_class.locate_recorded_ancestor(entry, gem_paths: [home])).to eq(shipped)
+    end
+  end
 end

--- a/spec/hyperdrive/artifact_status_spec.rb
+++ b/spec/hyperdrive/artifact_status_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Rails::Hyperdrive::ArtifactStatus do
     expect(status).to be_stale
   end
 
+  describe "how an entry prints itself" do
+    it "names the offering gem for a missing artifact" do
+      entry = compare([guideline(name: "auth-pundit")]).missing.first
+
+      expect(entry.to_s)
+        .to eq(".claude/hyperdrive/guidelines/auth-pundit.md (from rails-hyperdrive-x@1.0.0)")
+    end
+
+    it "prints an installed artifact as the bare path" do
+      artifacts = [guideline(name: "auth-pundit")]
+      install(artifacts)
+
+      entry = compare(artifacts).installed.first
+
+      expect(entry.to_s).to eq(".claude/hyperdrive/guidelines/auth-pundit.md")
+    end
+  end
+
   context "with a fully installed application" do
     let(:artifacts) { [guideline(name: "auth-pundit")] }
 

--- a/spec/hyperdrive/auto_install_spec.rb
+++ b/spec/hyperdrive/auto_install_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
     )
   end
 
-  def bundle_ships(artifacts)
-    allow(Rails::Hyperdrive::BundlerArtifactDiscovery).to receive(:discover).and_return(artifacts)
+  # `bundled` is what the discovery walk saw in the bundle, which is what
+  # tells a held artifact apart from one whose gem is gone.
+  def bundle_ships(artifacts, bundled: artifacts.map(&:source_gem).uniq)
+    allow(Rails::Hyperdrive::BundlerArtifactDiscovery).to receive(:discover) do |report: nil, **|
+      Array(bundled).each { |gem| report.bundled_gems << gem } if report
+      artifacts
+    end
   end
 
   def initialize_app(artifacts)
@@ -73,6 +78,17 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
       allow(::Bundler).to receive(:frozen_bundle?).and_return(true)
 
       expect(described_class.run(root: root).skipped).to eq(:not_development)
+    end
+
+    it "runs when Bundler cannot say whether the bundle is frozen" do
+      initialize_app([])
+      bundle_ships([guideline(name: "auth-pundit")])
+      allow(::Bundler).to receive(:frozen_bundle?).and_raise(::Bundler::GemfileNotFound)
+
+      result = described_class.run(root: root)
+
+      expect(result).to be_ran
+      expect(result.installed).to eq([".claude/hyperdrive/guidelines/auth-pundit.md"])
     end
 
     it "reports rather than raises when discovery blows up" do
@@ -235,7 +251,22 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
       result = described_class.run(root: root)
 
       expect(result.orphaned.map(&:path)).to eq([".claude/hyperdrive/guidelines/auth-pundit.md"])
+      expect(result.orphaned.map(&:to_s)).to eq(
+        [".claude/hyperdrive/guidelines/auth-pundit.md (no longer shipped by rails-hyperdrive-x@1.0.0)"]
+      )
       expect(File).to exist(File.join(root, ".claude/hyperdrive/guidelines/auth-pundit.md"))
+    end
+
+    it "says an artifact is held, not gone, while its source gem is still bundled" do
+      bundle_ships([], bundled: ["rails-hyperdrive-x"])
+
+      result = described_class.run(root: root)
+
+      expect(result.orphaned.map(&:to_s)).to eq(
+        [".claude/hyperdrive/guidelines/auth-pundit.md " \
+         "(rails-hyperdrive-x is still bundled but did not offer this file)"]
+      )
+      expect(result.messages.join("\n")).to include("is still bundled but did not offer this file")
     end
 
     it "never installs a disabled artifact" do
@@ -265,8 +296,9 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
 
     # The bundler-plugin hook prints result.messages and nothing else, so the
     # fence is invisible at bundle install unless it lands there.
-    def bundle_fences(warning, artifacts: [guideline(name: "auth-pundit")])
+    def bundle_fences(warning, artifacts: [guideline(name: "auth-pundit")], bundled: ["rails-hyperdrive-x"])
       allow(Rails::Hyperdrive::BundlerArtifactDiscovery).to receive(:discover) do |report:, **|
+        Array(bundled).each { |gem| report.bundled_gems << gem }
         report.fence(warning)
         artifacts
       end
@@ -319,7 +351,10 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
       result = described_class.run(root: root)
 
       expect(File.read(path)).to eq(before_body)
-      expect(result.orphaned.map(&:path)).to eq([".claude/hyperdrive/guidelines/auth-pundit.md"])
+      expect(result.orphaned.map(&:to_s)).to eq(
+        [".claude/hyperdrive/guidelines/auth-pundit.md " \
+         "(rails-hyperdrive-x is still bundled but did not offer this file)"]
+      )
       expect(result.messages.last).to include("upgrade rails-hyperdrive to install it")
     end
   end
@@ -391,6 +426,14 @@ RSpec.describe Rails::Hyperdrive::AutoInstall do
     path = File.join(root, Rails::Hyperdrive::InstallLayout::CONFIG_PATH)
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, document.is_a?(String) ? document : document.to_yaml)
+  end
+
+  describe Rails::Hyperdrive::AutoInstall::Result do
+    it "reports whether the run wrote anything" do
+      expect(described_class.new(installed: [".claude/agents/reviewer.md"])).to be_installed_anything
+      expect(described_class.new(installed: [])).not_to be_installed_anything
+      expect(described_class.new).not_to be_installed_anything
+    end
   end
 
   def with_env(vars)

--- a/spec/hyperdrive/bundler_artifact_discovery_spec.rb
+++ b/spec/hyperdrive/bundler_artifact_discovery_spec.rb
@@ -1373,6 +1373,28 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
         expect(skill.support_files.first[:body]).to eq("notes: sidekiq\n")
       end
 
+      # The relpath is what AncestorLocator reads a merge base back from, so it
+      # has to name the file the bytes actually came from.
+      it "records a template-side relpath for a rendered file and none for a content-side one" do
+        paired_skill(
+          template_files: { "references/notes.md.erb" => support_template },
+          content_files: { "references/static.md" => "static\n" }
+        )
+
+        skill, warnings = discover(sidekiq)
+
+        expect(warnings).to be_empty
+        expect(skill.source_root).to eq(@dir)
+        expect(skill.path).to eq(File.join(@dir, "lib/source_gem/hyperdrive/skills/paired/SKILL.md.erb"))
+        expect(skill.support_root).to eq(File.join(@dir, "skills/paired"))
+
+        rendered = skill.support_files.find { |f| f[:path] == "references/notes.md" }
+        static = skill.support_files.find { |f| f[:path] == "references/static.md" }
+        expect(rendered[:source_relpath])
+          .to eq("lib/source_gem/hyperdrive/skills/paired/references/notes.md")
+        expect(static).not_to have_key(:source_relpath)
+      end
+
       it "supersedes the content dir's same-target static face without a warning" do
         paired_skill(
           template_files: { "references/notes.md.erb" => support_template },
@@ -1644,6 +1666,22 @@ RSpec.describe Rails::Hyperdrive::BundlerArtifactDiscovery do
       results, warnings = discover
       expect(warnings.join).to include("malformed YAML")
       expect(results.first.target_gem).to eq(["*"])
+    end
+
+    # The whole manifest is discarded, so a gem-wide gate and fence go with it.
+    it "warns and installs everything ungated when the manifest cannot be read" do
+      write_skill("a")
+      manifest = File.join(@dir, "hyperdrive.yml")
+      write("hyperdrive.yml", "gem: absent_gem\nhyperdrive_version: \">= 99\"\n")
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(manifest).and_raise(Errno::EACCES, manifest)
+
+      results, warnings = discover
+
+      expect(warnings.join).to include("unreadable (Permission denied")
+      expect(results.map(&:name)).to eq(["a"])
+      expect(results.first.target_gem).to eq(["*"])
+      expect(fence_warnings).to be_empty
     end
 
     it "warns and proceeds as if absent when the manifest root is not a map" do

--- a/spec/hyperdrive/engine_safety_spec.rb
+++ b/spec/hyperdrive/engine_safety_spec.rb
@@ -47,3 +47,36 @@ RSpec.describe "Engine safety in non-development" do
     expect(status).to eq(403)
   end
 end
+
+RSpec.describe "Engine load-time warning" do
+  subject(:initializer) do
+    Rails::Hyperdrive::Engine.initializers.find { |i| i.name == "hyperdrive.warn_outside_development" }
+  end
+
+  let(:message) { "[hyperdrive] loaded outside development (Rails.env=production); MCP endpoints will return 403" }
+
+  before { allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) }
+
+  it "warns through the Rails logger when the engine loads outside development" do
+    logger = instance_double(Logger)
+    allow(::Rails).to receive(:logger).and_return(logger)
+
+    expect(logger).to receive(:warn).with(message)
+    initializer.run(Rails.application)
+  end
+
+  it "falls back to Kernel#warn before a logger exists" do
+    allow(::Rails).to receive(:logger).and_return(nil)
+
+    expect { initializer.run(Rails.application) }.to output("#{message}\n").to_stderr
+  end
+
+  it "stays silent in development" do
+    allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+    logger = instance_double(Logger)
+    allow(::Rails).to receive(:logger).and_return(logger)
+
+    expect(logger).not_to receive(:warn)
+    expect { initializer.run(Rails.application) }.not_to output.to_stderr
+  end
+end

--- a/spec/hyperdrive/generators/discover_generator_spec.rb
+++ b/spec/hyperdrive/generators/discover_generator_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe Rails::Generators::Hyperdrive::DiscoverGenerator do
 
   def path(rel) = File.join(@app_dir, rel)
 
+  describe "what it asks CompanionDiscovery for" do
+    it "passes the app's lockfile, the gitignored cache path, and no refresh" do
+      expect(Rails::Hyperdrive::CompanionDiscovery).to receive(:new).with(
+        lockfile_path: path("Gemfile.lock"),
+        cache_path: path(".hyperdrive/discover_cache.json"),
+        refresh: false
+      ).and_return(instance_double(Rails::Hyperdrive::CompanionDiscovery,
+        run: Result.new(suggestions: [], warnings: [], status: :online)))
+
+      run_generator([])
+    end
+
+    it "passes refresh: true under --refresh" do
+      expect(Rails::Hyperdrive::CompanionDiscovery).to receive(:new)
+        .with(hash_including(refresh: true))
+        .and_return(instance_double(Rails::Hyperdrive::CompanionDiscovery,
+          run: Result.new(suggestions: [], warnings: [], status: :online)))
+
+      run_generator(["--refresh"])
+    end
+  end
+
   describe ".gitignore management" do
     before { stub_discovery(Result.new(suggestions: [], warnings: [], status: :online)) }
 
@@ -47,6 +69,22 @@ RSpec.describe Rails::Generators::Hyperdrive::DiscoverGenerator do
       body = File.read(path(".gitignore"))
       expect(body).to include("/log")
       expect(body).to include(".hyperdrive/discover_cache.json")
+    end
+
+    it "starts a new line when the existing .gitignore has no trailing newline" do
+      File.write(path(".gitignore"), "/log\n/tmp")
+
+      run_generator([])
+
+      expect(File.read(path(".gitignore"))).to eq("/log\n/tmp\n.hyperdrive/discover_cache.json\n")
+    end
+
+    it "writes the rule alone into an empty .gitignore" do
+      File.write(path(".gitignore"), "")
+
+      run_generator([])
+
+      expect(File.read(path(".gitignore"))).to eq(".hyperdrive/discover_cache.json\n")
     end
 
     it "is idempotent — does not duplicate the rule" do

--- a/spec/hyperdrive/hyperdrive_spec.rb
+++ b/spec/hyperdrive/hyperdrive_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "rails/hyperdrive"
+
+RSpec.describe Rails::Hyperdrive do
+  describe ".root" do
+    it "points at the gem's lib directory" do
+      expect(File.file?(File.join(described_class.root, "rails/hyperdrive.rb"))).to be true
+    end
+
+    it "is memoized" do
+      expect(described_class.root).to equal(described_class.root)
+    end
+  end
+
+  describe ".dev_mode?" do
+    it "is true under Rails.env.development?" do
+      expect(described_class.dev_mode?).to be true
+    end
+
+    it "is false in any other environment" do
+      allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(described_class.dev_mode?).to be false
+    end
+  end
+end

--- a/spec/hyperdrive/install_pipeline_spec.rb
+++ b/spec/hyperdrive/install_pipeline_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
     end
   end
 
+  it "appends the import line to a CLAUDE.md the app already had" do
+    File.write(File.join(root, "CLAUDE.md"), "# my project\n")
+
+    run(artifacts: [guideline(name: "auth-pundit")])
+
+    expect(read("CLAUDE.md")).to start_with("# my project\n")
+    expect(read("CLAUDE.md")).to include("@.claude/hyperdrive/index.md")
+  end
+
   describe "additive mode" do
     let(:existing) { guideline(name: "auth-pundit") }
 
@@ -183,6 +192,44 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
 
       expect(exist?(".claude/hyperdrive/guidelines/auth-pundit.md")).to be true
       expect(read(".hyperdrive/lock.yml")).to include("auth-pundit")
+    end
+  end
+
+  describe "a hand-written file the lock never recorded" do
+    let(:gpath) { ".claude/hyperdrive/guidelines/auth-pundit.md" }
+    let(:artifact) { guideline(name: "auth-pundit") }
+
+    before do
+      FileUtils.mkdir_p(File.dirname(File.join(root, gpath)))
+      File.write(File.join(root, gpath), "# my own notes\n")
+    end
+
+    it "is left alone in preserve mode, and the run says how to reconcile it" do
+      out = run_reporting(artifacts: [artifact])
+
+      expect(read(gpath)).to eq("# my own notes\n")
+      expect(out).to include(
+        "#{gpath} (locally modified; run hyperdrive:sync with --merge, --sidecar, or --overwrite to reconcile)"
+      )
+      expect(lock_entry(gpath)).to be_nil
+    end
+
+    it "is replaced by the shipped body in overwrite mode" do
+      result = run(mode: :overwrite, artifacts: [artifact])
+
+      expect(read(gpath)).to start_with("# auth-pundit")
+      expect(result.installed).to include(gpath)
+      expect(lock_entry(gpath)["source"]).to eq("rails-hyperdrive-x@1.0.0")
+    end
+
+    # The branch that stops a bundle install from clobbering a hand-written agent.
+    it "is never overwritten by an additive run, which claims no lock entry either" do
+      result = run(mode: :additive, artifacts: [artifact])
+
+      expect(read(gpath)).to eq("# my own notes\n")
+      expect(result.installed).to be_empty
+      expect(result.skipped).to eq([gpath])
+      expect(lock_entry(gpath)).to be_nil
     end
   end
 
@@ -634,6 +681,24 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
       expect(out).to match(/unreviewed/)
     end
 
+    it "names a single ignored destination in the singular" do
+      File.write(File.join(root, ".gitignore"), ".hyperdrive/lock.yml\n")
+
+      out = run_reporting(artifacts: [guideline(name: "auth-pundit")])
+
+      expect(out).to include(
+        ".hyperdrive/lock.yml is gitignored; installed artifacts stay out of git status and " \
+        "pull-request diffs, so companion-shipped content reaches the agent unreviewed"
+      )
+    end
+
+    it "stays quiet when git cannot answer" do
+      FileUtils.rm_rf(File.join(root, ".git"))
+      File.write(File.join(root, ".gitignore"), ".claude/\n")
+
+      expect(run_reporting(artifacts: [guideline(name: "auth-pundit")])).not_to match(/gitignored/)
+    end
+
     it "stays quiet when they are tracked" do
       expect(run_reporting(artifacts: [guideline(name: "auth-pundit")])).not_to match(/gitignored/)
     end
@@ -787,6 +852,16 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
       expect(read(sidecar)).to include("UPGRADED rule.")
       expect(result.sidecars.map(&:dest)).to eq([gpath])
       expect(lock_source(gpath)).to eq("rails-hyperdrive-x@2.0.0")
+    end
+
+    it "treats a sidecar path it cannot hash as the user's work" do
+      FileUtils.mkdir_p(File.join(root, sidecar))
+
+      out = run_reporting(mode: :sidecar, artifacts: [v2])
+
+      expect(out).to include("#{sidecar} (sidecar locally modified; resolve or delete it)")
+      expect(File.directory?(File.join(root, sidecar))).to be true
+      expect(lock_source(gpath)).to eq("rails-hyperdrive-x@1.0.0")
     end
 
     it "writes the sidecar byte-identical to what a live install would write, so mv = accept upstream" do
@@ -1108,6 +1183,20 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
       expect(read("#{gpath}.new")).to include("line a (upstream)")
     end
 
+    it "degrades to a sidecar when the live file cannot be read" do
+      allow(Rails::Hyperdrive::AncestorLocator).to receive(:locate).and_return(v1_ready)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(File.join(root, gpath)).and_raise(Errno::EACCES)
+
+      out = run_reporting(mode: :merge, artifacts: [v2])
+
+      expect(out).to include(
+        "#{gpath} (locally modified; new upstream delivered to #{gpath}.new; binary content)"
+      )
+      expect(File.binread(File.join(root, gpath))).to include("line a (mine)")
+      expect(read("#{gpath}.new")).to include("line d (upstream)")
+    end
+
     it "degrades to a sidecar on binary content without invoking git" do
       allow(Rails::Hyperdrive::AncestorLocator).to receive(:locate).and_return("a\0b")
       expect(Open3).not_to receive(:capture3)
@@ -1254,7 +1343,7 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
       File.write(lock, data.to_yaml)
     end
 
-    %i[preserve overwrite additive].each do |mode|
+    %i[preserve overwrite sidecar merge additive].each do |mode|
       it "writes nothing and rewrites no lock in #{mode} mode" do
         before_lock = read(".hyperdrive/lock.yml")
 
@@ -1282,7 +1371,7 @@ RSpec.describe Rails::Hyperdrive::InstallPipeline do
       File.write(File.join(root, ".hyperdrive/lock.yml"), "files: [unterminated\n  : :\n")
     end
 
-    %i[preserve additive].each do |mode|
+    %i[preserve overwrite sidecar merge additive].each do |mode|
       it "warns once, writes nothing, and leaves the lock byte-untouched in #{mode} mode" do
         before_lock = read(".hyperdrive/lock.yml")
 

--- a/spec/hyperdrive/install_shell_spec.rb
+++ b/spec/hyperdrive/install_shell_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+require "rails/hyperdrive/install_shell"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe Rails::Hyperdrive::InstallShell do
+  let(:root) { Dir.mktmpdir("hyperdrive-shell") }
+  let(:io) { StringIO.new }
+
+  after { FileUtils.remove_entry(root) if File.directory?(root) }
+
+  subject(:shell) { described_class.new(root: root, io: io) }
+
+  def read(rel) = File.read(File.join(root, rel))
+
+  describe "#create_file" do
+    it "writes the content, creating missing directories" do
+      shell.create_file(".claude/agents/reviewer.md", "# reviewer\n")
+
+      expect(read(".claude/agents/reviewer.md")).to eq("# reviewer\n")
+      expect(io.string).to eq("      create  .claude/agents/reviewer.md\n")
+    end
+
+    it "overwrites an existing file" do
+      shell.create_file("a.md", "first\n")
+      shell.create_file("a.md", "second\n")
+
+      expect(read("a.md")).to eq("second\n")
+    end
+  end
+
+  describe "#append_to_file" do
+    it "adds to the end of an existing file" do
+      shell.create_file("CLAUDE.md", "# mine\n")
+
+      shell.append_to_file("CLAUDE.md", "@.claude/hyperdrive/index.md\n")
+
+      expect(read("CLAUDE.md")).to eq("# mine\n@.claude/hyperdrive/index.md\n")
+      expect(io.string).to include("      append  CLAUDE.md")
+    end
+  end
+
+  describe "#remove_file" do
+    it "removes a file and reports it" do
+      shell.create_file("a.md", "x\n")
+
+      shell.remove_file("a.md")
+
+      expect(File).not_to exist(File.join(root, "a.md"))
+      expect(io.string).to include("      remove  a.md")
+    end
+
+    it "removes a directory whole" do
+      shell.create_file("skills/x/SKILL.md", "x\n")
+
+      shell.remove_file("skills/x")
+
+      expect(File).not_to exist(File.join(root, "skills/x"))
+    end
+  end
+
+  describe "with pretend: true" do
+    subject(:shell) { described_class.new(root: root, io: io, pretend: true) }
+
+    it "reports every write without touching the tree" do
+      File.write(File.join(root, "CLAUDE.md"), "# mine\n")
+
+      shell.create_file("a.md", "x\n")
+      shell.append_to_file("CLAUDE.md", "appended\n")
+      shell.remove_file("CLAUDE.md")
+
+      expect(File).not_to exist(File.join(root, "a.md"))
+      expect(read("CLAUDE.md")).to eq("# mine\n")
+      expect(io.string.scan(/create|append|remove/)).to eq(%w[create append remove])
+    end
+  end
+
+  describe "with no io" do
+    subject(:shell) { described_class.new(root: root) }
+
+    it "writes silently" do
+      expect { shell.create_file("a.md", "x\n") }.not_to output.to_stdout
+
+      expect(read("a.md")).to eq("x\n")
+    end
+
+    it "still accepts say and say_status" do
+      expect { shell.say_status(:create, "a.md") }.not_to raise_error
+      expect { shell.say("hello") }.not_to raise_error
+    end
+  end
+
+  it "reports a plain message through say" do
+    shell.say("hello")
+    shell.say
+
+    expect(io.string).to eq("hello\n\n")
+  end
+
+  it "expands the root it was given" do
+    expect(described_class.new(root: "#{root}/./sub/..").root).to eq(File.expand_path(root))
+  end
+end

--- a/spec/hyperdrive/resources_spec.rb
+++ b/spec/hyperdrive/resources_spec.rb
@@ -16,13 +16,30 @@ RSpec.describe "MCP resources end-to-end" do
   end
 
   describe "hyperdrive://stack-profile" do
-    it "returns JSON describing the resolved StackProfile" do
-      resp = call_read("hyperdrive://stack-profile")
-      contents = resp[:result][:contents].first
-      expect(contents[:mimeType]).to eq("application/json")
+    let(:lockfile) { File.expand_path("../fixtures/gemfile_lock/standard.lock", __dir__) }
+
+    before do
+      allow(Rails::Hyperdrive::StackProfile).to receive(:default_lockfile_path).and_return(lockfile)
+    end
+
+    it "returns the resolved stack facts as JSON" do
+      contents = call_read("hyperdrive://stack-profile")[:result][:contents].first
       payload = JSON.parse(contents[:text])
-      # spec/internal ships no Gemfile.lock, so the profile resolves to the :error sentinel.
-      expect(payload.keys).to include("rails", "ruby")
+
+      expect(contents[:uri]).to eq("hyperdrive://stack-profile")
+      expect(contents[:mimeType]).to eq("application/json")
+      expect(payload["rails"]).to eq("version" => "8.0.1", "major" => 8)
+      expect(payload["ruby"]["version"]).to start_with("3.3.6")
+      expect(payload["database"]["adapter"]).to eq("sqlite3")
+      expect(payload).not_to have_key("error")
+    end
+
+    it "lists the app's direct dependencies only" do
+      payload = JSON.parse(call_read("hyperdrive://stack-profile")[:result][:contents].first[:text])
+      names = payload["direct_dependencies"].map { |d| d["name"] }
+
+      expect(names).to include("devise", "pundit", "sidekiq")
+      expect(names).not_to include("minitest", "actionpack")
     end
   end
 
@@ -45,6 +62,22 @@ RSpec.describe "MCP resources end-to-end" do
     end
   end
 
+  describe "an URI belonging to no resource family" do
+    it "reports invalid params naming the URI" do
+      resp = call_read("hyperdrive://nope")
+
+      expect(resp[:error][:code]).to eq(-32602)
+      expect(resp[:error][:data]).to include("Resource not found: hyperdrive://nope")
+      expect(resp[:result]).to be_nil
+    end
+
+    it "reports a missing uri param the same way" do
+      req = { jsonrpc: "2.0", id: 1, method: "resources/read", params: {} }
+
+      expect(server.handle(req)[:error][:data]).to include("Resource not found:")
+    end
+  end
+
   describe "resources/list" do
     it "advertises hyperdrive://stack-profile and any installed hyperdrive://skills/* URIs" do
       req = { jsonrpc: "2.0", id: 1, method: "resources/list", params: {} }
@@ -52,6 +85,16 @@ RSpec.describe "MCP resources end-to-end" do
       uris = resp[:result][:resources].map { |r| r[:uri] }
       expect(uris).to include("hyperdrive://stack-profile")
       expect(uris).to include("hyperdrive://skills/sample")
+    end
+  end
+
+  describe "resources/templates/list" do
+    it "advertises the skill template" do
+      req = { jsonrpc: "2.0", id: 1, method: "resources/templates/list", params: {} }
+      resp = Rails::Hyperdrive::McpServer.server.handle(req)
+
+      expect(resp[:result][:resourceTemplates].map { |t| t[:uriTemplate] })
+        .to include("hyperdrive://skills/{name}")
     end
   end
 end

--- a/spec/hyperdrive/safety_spec.rb
+++ b/spec/hyperdrive/safety_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe Rails::Hyperdrive::Safety::RackMiddleware do
     expect(status).to eq(403)
     expect(body.first).to include("origin not allowed")
   end
+
+  it "403s when the Origin header is not a parseable URI" do
+    status, _h, body = mw.call({"HTTP_ORIGIN" => "http://exa mple.com"})
+    expect(status).to eq(403)
+    expect(body.first).to include("origin not allowed: http://exa mple.com")
+  end
+
+  it "reports the environment it refused under" do
+    allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("staging"))
+    _s, _h, body = mw.call({})
+    expect(JSON.parse(body.first)).to eq(
+      "error" => "forbidden", "reason" => "hyperdrive is dev-only (Rails.env=staging)"
+    )
+  end
 end

--- a/spec/hyperdrive/sidecar_resolver_spec.rb
+++ b/spec/hyperdrive/sidecar_resolver_spec.rb
@@ -352,6 +352,35 @@ RSpec.describe Rails::Hyperdrive::SidecarResolver do
       expect(io.string).to include("could not be read", "using the default prompt")
       expect(dump["argv"].first).to include("You are resolving one file")
     end
+
+    # There is nothing left to fall back to, so the failure has to be this
+    # candidate's reason rather than a silently different prompt.
+    it "reports the shipped prompt failing as the candidate's unresolved reason" do
+      allow(Rails::Hyperdrive::ResolvePrompt)
+        .to receive(:default_template).and_raise(Errno::ENOENT, "resolve/prompt.md.erb")
+
+      outcome = resolve(command: "bin/dump $PROMPT")
+
+      expect(outcome.resolved).to be_empty
+      expect(outcome.unresolved.first[:dest]).to eq(dest)
+      expect(outcome.unresolved.first[:reason]).to include("resolve/prompt.md.erb")
+      expect(File).to exist(File.join(root, sidecar))
+      expect(File).not_to exist(File.join(root, "dump.yml"))
+    end
+  end
+
+  it "leaves a leftover sidecar it cannot hash alone as user work" do
+    install_sidecar
+    accept_script
+    allow(File).to receive(:binread).and_call_original
+    allow(File).to receive(:binread).with(File.join(root, sidecar)).and_raise(Errno::EACCES)
+
+    outcome = resolve(command: "bin/accept $MERGED")
+
+    expect(outcome.resolved).to be_empty
+    expect(outcome.skipped).to eq([dest])
+    expect(io.string).to include("sidecar locally modified; resolve or delete it by hand")
+    expect(File.read(File.join(root, dest))).to eq(live_body)
   end
 
   it "keeps a value holding spaces as one argument" do

--- a/spec/hyperdrive/skill_tasks_spec.rb
+++ b/spec/hyperdrive/skill_tasks_spec.rb
@@ -6,10 +6,14 @@ require "tmpdir"
 RSpec.describe "hyperdrive rake tasks" do
   around { |ex| Dir.mktmpdir { |d| @dir = d; ex.run } }
 
-  before do
+  # Loaded once and re-enabled per example: `load` recompiles the file, which
+  # resets its coverage counters to what the last-loaded copy happened to run.
+  before(:context) do
     Rake.application = Rake::Application.new
     load File.expand_path("../../lib/hyperdrive/skill_tasks.rb", __dir__)
   end
+
+  before { Rake.application.tasks.each(&:reenable) }
 
   def write(rel, body)
     path = File.join(@dir, rel)
@@ -116,7 +120,9 @@ RSpec.describe "hyperdrive rake tasks" do
     end.to output(/render /).to_stdout
     expect(File.file?(File.join(@dir, "skills/paired/SKILL.md"))).to be true
   end
+end
 
+RSpec.describe "requiring the hyperdrive rake tasks" do
   # Subprocess so the real require machinery runs without touching the suite's Rake application.
   it "defines every task through `require \"hyperdrive/skill_tasks\"`" do
     lib = File.expand_path("../../lib", __dir__)

--- a/spec/hyperdrive/skill_template_spec.rb
+++ b/spec/hyperdrive/skill_template_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Rails::Hyperdrive::SkillTemplate do
     it "is false with a requirement when the gem is absent" do
       expect(render(%(<%= gem?("view_component", ">= 0") %>))).to eq("false")
     end
+
+    it "is false for a requirement that will not parse, rather than blowing up the render" do
+      expect(render(%(<%= gem?("alba", "newest") %>))).to eq("false")
+    end
   end
 
   describe "any_gem?" do

--- a/spec/hyperdrive/stack_profile_spec.rb
+++ b/spec/hyperdrive/stack_profile_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "tmpdir"
+require "digest"
 require "rails/hyperdrive/stack_profile"
 require "rails/hyperdrive/bundler_artifact_discovery"
 require "rails/hyperdrive/config_file"
@@ -76,5 +77,119 @@ RSpec.describe Rails::Hyperdrive::StackProfile do
     allow(Rails::Hyperdrive::BundlerArtifactDiscovery)
       .to receive(:discover).and_raise(StandardError, "bundler exploded")
     expect(described_class.from_lockfile(lockfile).to_h[:gem_skills]).to eq([])
+  end
+
+  describe "the default lockfile path" do
+    it "reads Rails.root's Gemfile.lock when Rails is booted" do
+      expect(described_class.default_lockfile_path).to eq(Rails.root.join("Gemfile.lock").to_s)
+    end
+
+    it "falls back to the working directory when no Rails root is available" do
+      allow(::Rails).to receive(:respond_to?).with(:root).and_return(false)
+
+      expect(described_class.default_lockfile_path).to eq(File.expand_path("Gemfile.lock", Dir.pwd))
+    end
+  end
+
+  describe "the database adapter" do
+    def lockfile_declaring(gem_name, version)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "Gemfile.lock")
+        File.write(path, <<~LOCK)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              railties (8.0.1)
+              #{gem_name} (#{version})
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            #{gem_name}
+
+          BUNDLED WITH
+             2.5.22
+        LOCK
+        yield path, dir
+      end
+    end
+
+    # An app_root with no config/database.yml is what forces the gem-hint path.
+    def adapter_for(gem_name, version)
+      lockfile_declaring(gem_name, version) do |path, dir|
+        described_class.from_lockfile(path, app_root: dir).to_h[:database]
+      end
+    end
+
+    it "reads mysql2 from the resolved gems" do
+      expect(adapter_for("mysql2", "0.5.6")).to eq(adapter: "mysql2")
+    end
+
+    it "reads trilogy from the resolved gems" do
+      expect(adapter_for("trilogy", "2.8.1")).to eq(adapter: "trilogy")
+    end
+
+    it "reads sqlite3 from the resolved gems" do
+      expect(adapter_for("sqlite3", "2.1.0")).to eq(adapter: "sqlite3")
+    end
+
+    it "reports no adapter when nothing names one" do
+      expect(adapter_for("rake", "13.2.1")).to eq({})
+    end
+
+    it "falls back to gem hints when config/database.yml cannot be parsed" do
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "config"))
+        File.write(File.join(root, "config/database.yml"), "development:\n\tadapter: [unterminated\n")
+
+        expect(described_class.from_lockfile(lockfile, app_root: root).to_h[:database])
+          .to eq(adapter: "postgresql")
+      end
+    end
+  end
+
+  describe "gem_skills_info" do
+    let(:skill) do
+      Rails::Hyperdrive::BundlerArtifactDiscovery::Artifact.new(
+        name: "alpha-skill", artifact_type: :skill, target_gem: ["devise"],
+        source_gem: "rails-hyperdrive-alpha", spec_version: "1.2.0",
+        path: "/gems/rails-hyperdrive-alpha-1.2.0/skills/alpha-skill/SKILL.md",
+        body: "---\nname: alpha-skill\n---\n"
+      )
+    end
+
+    let(:guideline) do
+      Rails::Hyperdrive::BundlerArtifactDiscovery::Artifact.new(
+        name: "alpha-guide", artifact_type: :guideline, source_gem: "rails-hyperdrive-alpha",
+        spec_version: "1.2.0", path: "/gems/x/guidelines/alpha-guide.md", body: "body\n"
+      )
+    end
+
+    before do
+      allow(Rails::Hyperdrive::BundlerArtifactDiscovery)
+        .to receive(:discover).and_return([skill, guideline])
+    end
+
+    it "describes each installed skill with its provenance and body hash" do
+      expect(profile[:gem_skills]).to eq([{
+        name: "alpha-skill",
+        gem: ["devise"],
+        source: "rails-hyperdrive-alpha",
+        version: "1.2.0",
+        path: "/gems/rails-hyperdrive-alpha-1.2.0/skills/alpha-skill/SKILL.md",
+        sha256: Digest::SHA256.hexdigest(skill.body)
+      }])
+    end
+
+    it "reports a universal skill's target as [\"*\"]" do
+      skill.target_gem = ["*"]
+
+      expect(profile[:gem_skills].first[:gem]).to eq(["*"])
+    end
+
+    it "reports skills only, never the other artifact kinds" do
+      expect(profile[:gem_skills].map { |s| s[:name] }).to eq(["alpha-skill"])
+    end
   end
 end

--- a/spec/hyperdrive/three_way_merge_spec.rb
+++ b/spec/hyperdrive/three_way_merge_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Rails::Hyperdrive::ThreeWayMerge do
     expect(outcome.status).to eq(:unavailable)
   end
 
+  it "reports :unavailable when git dies without a conflict count" do
+    status = instance_double(Process::Status, success?: false, exited?: false, exitstatus: nil)
+    allow(Open3).to receive(:capture3).and_return(["", "", status])
+
+    outcome = described_class.merge(ours: base, base: base, theirs: base)
+
+    expect(outcome.status).to eq(:unavailable)
+    expect(outcome.body).to be_nil
+  end
+
   it "rejects binary input without invoking git" do
     expect(Open3).not_to receive(:capture3)
 

--- a/spec/hyperdrive/tools_base_spec.rb
+++ b/spec/hyperdrive/tools_base_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+require "rails/hyperdrive/mcp_server"
+
+RSpec.describe Rails::Hyperdrive::Tools::Base do
+  def text(response)
+    response.to_h[:content].first[:text]
+  end
+
+  describe ".with_dev_guard" do
+    it "yields and returns the block's response in development" do
+      response = described_class.with_dev_guard { described_class.respond_text("ran") }
+      expect(response.to_h[:isError]).to be_falsey
+      expect(text(response)).to eq("ran")
+    end
+
+    it "refuses to yield outside development" do
+      allow(Rails::Hyperdrive).to receive(:dev_mode?).and_return(false)
+      yielded = false
+
+      response = described_class.with_dev_guard { yielded = true }
+
+      expect(yielded).to be false
+      expect(response.to_h[:isError]).to be true
+      expect(text(response)).to eq("hyperdrive tools are disabled outside Rails.env.development?")
+    end
+
+    it "shapes an exception raised in the block into an error response" do
+      response = described_class.with_dev_guard { raise ArgumentError, "bad input" }
+
+      expect(response.to_h[:isError]).to be true
+      expect(text(response)).to eq("ArgumentError: bad input")
+    end
+  end
+
+  describe "every registered tool" do
+    it "refuses to run outside development" do
+      allow(Rails::Hyperdrive).to receive(:dev_mode?).and_return(false)
+      arguments = {
+        "run_ruby" => { code: "1" }, "run_sql" => { sql: "SELECT 1" },
+        "locate_source" => { reference: "User" }, "lookup_doc" => { reference: "String" }
+      }
+
+      Rails::Hyperdrive::McpServer::TOOLS.each do |tool|
+        response = tool.call(**arguments.fetch(tool.tool_name, {}))
+        expect(response.to_h[:isError]).to(be(true), "expected #{tool.tool_name} to refuse")
+        expect(text(response)).to eq("hyperdrive tools are disabled outside Rails.env.development?")
+      end
+    end
+  end
+end

--- a/spec/hyperdrive/tools_spec.rb
+++ b/spec/hyperdrive/tools_spec.rb
@@ -32,10 +32,28 @@ RSpec.describe "MCP tools end-to-end" do
   end
 
   describe "describe_app" do
-    it "returns JSON containing :rails and :ruby keys" do
-      resp = call_tool("describe_app")
-      json = JSON.parse(text_payload(resp))
-      expect(json.keys).to include("rails", "ruby")
+    let(:lockfile) { File.expand_path("../fixtures/gemfile_lock/standard.lock", __dir__) }
+
+    before do
+      allow(Rails::Hyperdrive::StackProfile).to receive(:default_lockfile_path).and_return(lockfile)
+    end
+
+    it "reports the stack facts parsed from the app's lockfile" do
+      json = JSON.parse(text_payload(call_tool("describe_app")))
+
+      expect(json["rails"]).to eq("version" => "8.0.1", "major" => 8)
+      expect(json["ruby"]["version"]).to start_with("3.3.6")
+      expect(json["database"]["adapter"]).to eq("sqlite3")
+      expect(json).not_to have_key("error")
+    end
+
+    it "reports direct dependencies and omits resolved-but-transitive gems" do
+      json = JSON.parse(text_payload(call_tool("describe_app")))
+      names = json["direct_dependencies"].map { |d| d["name"] }
+
+      expect(json["direct_dependencies"]).to include("name" => "devise", "version" => "4.9.4")
+      expect(names).to include("pundit", "sidekiq")
+      expect(names).not_to include("minitest", "actionpack")
     end
   end
 
@@ -80,53 +98,207 @@ RSpec.describe "MCP tools end-to-end" do
       expect(resp[:result][:isError]).to be true
       expect(text_payload(resp)).to start_with("SQL not allowed:")
     end
+
+    it "reports an allowed statement the database rejects" do
+      resp = call_tool("run_sql", { "sql" => "SELECT * FROM no_such_table" })
+
+      expect(resp[:result][:isError]).to be true
+      expect(text_payload(resp)).to start_with("ActiveRecord::StatementInvalid:")
+      expect(text_payload(resp)).to include("no_such_table")
+    end
   end
 
   describe "list_models" do
-    it "lists User and Post with the spec-mandated keys" do
-      resp = call_tool("list_models")
-      payload = JSON.parse(text_payload(resp))
-      classes = payload.map { |m| m["class"] }
-      expect(classes).to include("User", "Post")
+    subject(:payload) { JSON.parse(text_payload(call_tool("list_models"))) }
+
+    # Columns come back empty until the process has opened a connection.
+    before { User.count }
+
+    it "describes every model's table, columns, validators, and associations" do
       user = payload.find { |m| m["class"] == "User" }
-      expect(user).to include("table", "columns", "validators", "associations")
+      post = payload.find { |m| m["class"] == "Post" }
+
+      expect(payload.map { |m| m["class"] }).to include("Post", "User")
+      expect(user["table"]).to eq("users")
+      expect(user["columns"]).to include(hash_including("name" => "email", "type" => "string"))
+      expect(user["validators"]).to include(hash_including("attribute" => "email", "kind" => "presence"))
+      expect(user["associations"]).to include(
+        { "name" => "posts", "macro" => "has_many", "class_name" => "Post" }
+      )
+      expect(post["associations"]).to include(
+        { "name" => "user", "macro" => "belongs_to", "class_name" => "User" }
+      )
+    end
+
+    it "sorts models by class name" do
+      classes = payload.map { |m| m["class"] }
+      expect(classes).to eq(classes.sort)
+    end
+
+    it "reports a model whose description blows up without dropping the rest" do
+      allow(Rails::Hyperdrive::Tools::ListModels).to receive(:describe).and_call_original
+      allow(Rails::Hyperdrive::Tools::ListModels)
+        .to receive(:describe).with(User).and_raise(TypeError, "broken class")
+
+      user = payload.find { |m| m["class"] == "User" }
+      expect(user).to eq("class" => "User", "errors" => ["TypeError: broken class"])
+      expect(payload.find { |m| m["class"] == "Post" }).to include("table" => "posts")
+    end
+
+    describe "per-facet failures" do
+      let(:tool) { Rails::Hyperdrive::Tools::ListModels }
+      let(:model) { class_double(ActiveRecord::Base, name: "Broken") }
+
+      it "inlines the error when a scalar attribute raises" do
+        allow(model).to receive(:table_name).and_raise(RuntimeError, "no table")
+        expect(tool.safe(model, :table_name)).to eq("<error: RuntimeError: no table>")
+      end
+
+      it "reports the error as the sole column when columns raise" do
+        allow(model).to receive(:connected?).and_return(true)
+        allow(model).to receive(:columns).and_raise(ActiveRecord::StatementInvalid, "no such table")
+
+        expect(tool.safe_columns(model)).to eq([{ error: "ActiveRecord::StatementInvalid: no such table" }])
+      end
+
+      it "reports no columns before a connection exists" do
+        allow(model).to receive(:connected?).and_return(false)
+        allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+
+        expect(tool.safe_columns(model)).to eq([])
+      end
+
+      it "falls back to an empty list when validators raise" do
+        allow(model).to receive(:validators).and_raise(NoMethodError, "nope")
+        expect(tool.safe_validators(model)).to eq([])
+      end
+
+      it "falls back to an empty list when associations raise" do
+        allow(model).to receive(:reflect_on_all_associations).and_raise(NoMethodError, "nope")
+        expect(tool.safe_associations(model)).to eq([])
+      end
+
+      it "reports a nil class_name for an association that cannot name its class" do
+        association = double("reflection", name: :things, macro: :has_many)
+        allow(association).to receive(:class_name).and_raise(NameError, "uninitialized constant Thing")
+        allow(model).to receive(:reflect_on_all_associations).and_return([association])
+
+        expect(tool.safe_associations(model))
+          .to eq([{ name: "things", macro: "has_many", class_name: nil }])
+      end
     end
   end
 
   describe "locate_source" do
-    it "resolves a constant to file:line text via const_source_location" do
-      resp = call_tool("locate_source", { "reference" => "User" })
-      expect(resp[:result][:isError]).to be_falsey
-      expect(text_payload(resp)).to match(/user\.rb:\d+\z/)
+    def resolve(reference)
+      resp = call_tool("locate_source", { "reference" => reference })
+      [resp[:result][:isError], text_payload(resp)]
     end
 
-    it "resolves dep:<gem> to the gem path" do
-      resp = call_tool("locate_source", { "reference" => "dep:rspec-core" })
-      unless resp[:result][:isError]
-        expect(text_payload(resp)).to include("rspec-core")
-      end
+    it "resolves a bare constant through const_source_location" do
+      error, text = resolve("User")
+      expect(error).to be_falsey
+      expect(text).to match(%r{/user\.rb:\d+\z})
     end
 
-    it "returns 'could not resolve:' for unknown references" do
-      resp = call_tool("locate_source", { "reference" => "NoSuchConstantXYZ" })
-      expect(resp[:result][:isError]).to be true
-      expect(text_payload(resp)).to start_with("could not resolve:")
+    it "resolves a namespaced constant against its owning module" do
+      error, text = resolve("Rails::Hyperdrive::Safety::RackMiddleware::DEFAULT_ALLOWED_HOSTS")
+      expect(error).to be_falsey
+      expect(text).to match(%r{/lib/rails/hyperdrive/safety/rack_middleware\.rb:\d+\z})
+    end
+
+    it "resolves Const#instance_method" do
+      error, text = resolve("Rails::Hyperdrive::StackProfile#parse!")
+      expect(error).to be_falsey
+      expect(text).to match(%r{/lib/rails/hyperdrive/stack_profile\.rb:\d+\z})
+    end
+
+    it "resolves Const.class_method" do
+      error, text = resolve("Rails::Hyperdrive::StackProfile.from_lockfile")
+      expect(error).to be_falsey
+      expect(text).to match(%r{/lib/rails/hyperdrive/stack_profile\.rb:\d+\z})
+    end
+
+    it "resolves dep:<gem> to the gem's full path" do
+      error, text = resolve("dep:rspec-core")
+      expect(error).to be_falsey
+      expect(text).to match(%r{/rspec-core-\d+\.\d+})
+      expect(File.directory?(text)).to be true
+    end
+
+    it "refuses an instance method the class does not define" do
+      expect(resolve("User#no_such_method")).to eq([true, "could not resolve: User#no_such_method"])
+    end
+
+    it "refuses a class method the class does not respond to" do
+      expect(resolve("User.no_such_method")).to eq([true, "could not resolve: User.no_such_method"])
+    end
+
+    it "refuses a method defined in C, which reports no source location" do
+      expect(resolve("String#strip")).to eq([true, "could not resolve: String#strip"])
+      expect(resolve("String.new")).to eq([true, "could not resolve: String.new"])
+    end
+
+    it "refuses an unknown constant" do
+      expect(resolve("NoSuchConstantXYZ")).to eq([true, "could not resolve: NoSuchConstantXYZ"])
+    end
+
+    it "refuses a method reference whose namespace does not exist" do
+      expect(resolve("NoSuch::Thing#call")).to eq([true, "could not resolve: NoSuch::Thing#call"])
+    end
+
+    it "refuses an unbundled dep:<gem>" do
+      expect(resolve("dep:no_such_gem_xyz")).to eq([true, "could not resolve: dep:no_such_gem_xyz"])
+    end
+
+    it "constantizes without ActiveSupport's String#constantize" do
+      allow(String).to receive(:method_defined?).with(:constantize).and_return(false)
+
+      expect(Rails::Hyperdrive::Tools::LocateSource.constantize("Rails::Hyperdrive::StackProfile"))
+        .to equal(Rails::Hyperdrive::StackProfile)
     end
   end
 
   describe "tail_logs" do
-    it "returns a body even if log file is small" do
-      log_path = Rails.root.join("log", "#{Rails.env}.log")
+    let(:log_path) { Rails.root.join("log", "#{Rails.env}.log") }
+
+    before do
       FileUtils.mkdir_p(log_path.dirname)
-      File.write(log_path, "line1\nline2\nline3\n")
-      resp = call_tool("tail_logs", { "lines" => 2 })
-      expect(text_payload(resp)).to include("line")
+      File.write(log_path, (1..5).map { |n| "line#{n}\n" }.join)
     end
 
-    it "refuses a file: outside Rails.root/log/" do
+    after { FileUtils.rm_f(log_path) }
+
+    it "returns only the trailing lines asked for" do
+      expect(text_payload(call_tool("tail_logs", { "lines" => 2 }))).to eq("line4\nline5\n")
+    end
+
+    it "returns the whole file when it holds fewer lines than requested" do
+      expect(text_payload(call_tool("tail_logs", { "lines" => 100 })))
+        .to eq("line1\nline2\nline3\nline4\nline5\n")
+    end
+
+    it "reads a named file under log/" do
+      File.write(Rails.root.join("log", "other.log"), "other\n")
+
+      expect(text_payload(call_tool("tail_logs", { "file" => "other.log" }))).to eq("other\n")
+    ensure
+      FileUtils.rm_f(Rails.root.join("log", "other.log"))
+    end
+
+    it "refuses a file: that escapes Rails.root/log/" do
       resp = call_tool("tail_logs", { "file" => "../config/database.yml" })
+
       expect(resp[:result][:isError]).to be true
-      expect(text_payload(resp)).to include("log not allowed").or include("log not found")
+      expect(text_payload(resp)).to eq("log not allowed: path escapes Rails.root/log/")
+    end
+
+    it "reports a log file that does not exist" do
+      resp = call_tool("tail_logs", { "file" => "absent.log" })
+
+      expect(resp[:result][:isError]).to be true
+      expect(text_payload(resp)).to start_with("log not found:")
+      expect(text_payload(resp)).to end_with("log/absent.log")
     end
   end
 
@@ -142,10 +314,49 @@ RSpec.describe "MCP tools end-to-end" do
   end
 
   describe "lookup_doc" do
-    it "returns text or a respond_error wrapper" do
-      resp = call_tool("lookup_doc", { "reference" => "String" })
-      # `ri` may be present or absent on the test host. Both shapes are valid.
-      expect(text_payload(resp)).to be_a(String)
+    let(:tool) { Rails::Hyperdrive::Tools::LookupDoc }
+
+    def stub_ri(stdout:, stderr:, status:)
+      allow(Open3).to receive(:popen3) do |*args, &block|
+        expect(args).to eq(["ri", "-T", "--format=markdown", "String#strip"])
+        block.call(nil, StringIO.new(stdout), StringIO.new(stderr), double(pid: 4321, value: status))
+      end
+    end
+
+    it "returns ri's markdown on success" do
+      stub_ri(stdout: "# String#strip\n", stderr: "", status: double(success?: true))
+
+      resp = call_tool("lookup_doc", { "reference" => "String#strip" })
+      expect(resp[:result][:isError]).to be_falsey
+      expect(text_payload(resp)).to eq("# String#strip\n")
+    end
+
+    it "reports ri's exit status and first stderr line on failure" do
+      stub_ri(stdout: "", stderr: "Nothing known about String#strip\nmore\n",
+        status: double(success?: false, exitstatus: 1))
+
+      resp = call_tool("lookup_doc", { "reference" => "String#strip" })
+      expect(resp[:result][:isError]).to be true
+      expect(text_payload(resp)).to eq("ri exited 1: Nothing known about String#strip")
+    end
+
+    it "reports a missing ri executable" do
+      allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT, "ri")
+
+      resp = call_tool("lookup_doc", { "reference" => "String#strip" })
+      expect(resp[:result][:isError]).to be true
+      expect(text_payload(resp)).to eq("ri not available")
+    end
+
+    it "TERMs a hung ri and reports the timeout" do
+      stub_ri(stdout: "", stderr: "", status: double(success?: true))
+      allow(::Timeout).to receive(:timeout).and_raise(::Timeout::Error)
+      expect(Process).to receive(:kill).with("TERM", 4321).and_raise(Errno::ESRCH)
+
+      resp = call_tool("lookup_doc", { "reference" => "String#strip" })
+      expect(resp[:result][:isError]).to be true
+      expect(text_payload(resp))
+        .to eq("ri exited 124: ri timeout after #{tool::RI_TIMEOUT_SECONDS}s")
     end
   end
 end


### PR DESCRIPTION
The unit suite sat at 97.65% line coverage, with 73 lines that no example reached. Most of them were the branches that matter least in the happy path and most when something goes wrong: the dev guards, the rescue arms, the fail-open paths, and the wordings the installer prints when it refuses to do something. This adds examples for all of them, so the suite now covers every line in `lib/`.

Nothing under `lib/` or `bundler-hyperdrive/` changes. This is spec-only.

## What is now pinned

**Safety.** A new `tools_base_spec.rb` covers `with_dev_guard`'s refuse and rescue arms, and loops over all eight tools asserting each one refuses outside development. `engine_safety_spec.rb` picks up the load-time warning down all three paths: through the Rails logger, through `Kernel#warn` when there is no logger, and silent in development.

**Tools.** `describe_app` and the `hyperdrive://stack-profile` resource previously only asserted the error payload; they now assert the real Rails, Ruby, and database facts plus direct-only dependencies against the fixture lockfile. Added `Const#method`, `Const.method`, `::`-namespaced, and `dep:` resolution for `locate_source` along with each refusal, every `list_models` rescue, exact `tail_logs` tailing and both of its refusals, and `run_sql` on a rejected statement. `lookup_doc` was asserting that either of two shapes was acceptable; it now stubs `Open3.popen3` and pins success, a non-zero exit, a missing `ri`, and a timeout that TERMs the child.

**Install and drift.** Adoption of a hand-written unlocked file in both `:preserve` and `:overwrite`, the additive branch that refuses to clobber it, both backstop loops (schema-ahead and unreadable lock) across all five modes, an unreadable live body during a merge, an unhashable sidecar, and the exact gitignore warning text in both its singular and plural forms plus the no-repo fail-open. New `install_shell_spec.rb` for the plain-FileUtils shell.

**Reconciliation.** The shipped resolve prompt failing to render, surfaced as that candidate's `unresolved` reason rather than masked by a fallback; an unhashable leftover sidecar; `AncestorLocator.resolved_bundle` built from the live bundle instead of an injected map, its failure rung, and all three of its never-raises rescues.

**Discovery and status.** An unreadable `hyperdrive.yml` driven through `BundlerArtifactDiscovery`, asserting both that the warning prints and that the gem-wide gate and fence are both discarded. `bundle_ships` now populates `report.bundled_gems`, so both orphan flavors are asserted through `LockFile.orphan_reason` in `ArtifactStatus` and `AutoInstall` alike, and the fenced-artifact example finally asserts the held wording it was named for.

## Two coverage artifacts fixed along the way

`skill_tasks_spec.rb` re-`load`ed `lib/hyperdrive/skill_tasks.rb` once per example. Each `load` recompiles the file and resets its coverage counters to whatever the last-loaded copy happened to execute, so the reported figure depended on example order. It now loads once per group and re-enables the tasks between examples.

`bundler-hyperdrive/plugins.rb` had the same defect in `plugins_spec.rb`. It reads as covered in default order but dropped the total to 99.94% under some seeds. Same one-load fix.

## Verification

1162 examples, 0 failures. Line coverage 100.0% (3108/3108), stable across seeds.